### PR TITLE
feat: transform classes to use lmdc- prefix instead of mdc-

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -47,17 +47,17 @@
     </style>
   </head>
   <body ng-app="demo">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Buttons</span>
+          <span class="lmdc-toolbar__title catalog-title">Buttons</span>
         </section>
       </div>
     </header>
-    <main class="mdc-toolbar-fixed-adjust" ng-controller="MainCtrl">
+    <main class="lmdc-toolbar-fixed-adjust" ng-controller="MainCtrl">
 
       <section class="hero">
         <div>
@@ -112,14 +112,14 @@
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Text Button</legend>
+          <legend class="lmdc-typography--title">Text Button</legend>
           
           <button mdc-button ng-disabled="isDisabled">Baseline</button>
           <button mdc-button compact="true" ng-disabled="isDisabled">Compact</button>
           <button mdc-button dense="true" ng-disabled="isDisabled">Dense</button>
           <button mdc-button class="secondary-text-button" ng-disabled="isDisabled">Secondary</button>
           <button mdc-button ng-disabled="isDisabled">
-            <mdc-icon class="mdc-button__icon">favorite</mdc-icon> Icon
+            <mdc-icon class="lmdc-button__icon">favorite</mdc-icon> Icon
           </button>
           <a mdc-button href="javascript:void(0);" ng-disabled="isDisabled">
             Link
@@ -127,14 +127,14 @@
         </fieldset>
 
         <fieldset>
-          <legend class="mdc-typography--title">Raised Button</legend>
+          <legend class="lmdc-typography--title">Raised Button</legend>
           
           <button mdc-button raised="true" ng-disabled="isDisabled">Baseline</button>
           <button mdc-button raised="true" compact="true" ng-disabled="isDisabled">Compact</button>
           <button mdc-button raised="true" dense="true" ng-disabled="isDisabled">Dense</button>
           <button mdc-button raised="true" class="secondary-filled-button" ng-disabled="isDisabled">Secondary</button>
           <button mdc-button raised="true" ng-disabled="isDisabled">
-            <mdc-icon class="mdc-button__icon">favorite</mdc-icon> Icon
+            <mdc-icon class="lmdc-button__icon">favorite</mdc-icon> Icon
           </button>
           <a mdc-button raised="true" href="javascript:void(0);" ng-disabled="isDisabled">
             Link
@@ -142,14 +142,14 @@
         </fieldset>
 
         <fieldset>
-          <legend class="mdc-typography--title">Unelevated Button (Experimental)</legend>
+          <legend class="lmdc-typography--title">Unelevated Button (Experimental)</legend>
 
           <button mdc-button unelevated="true" ng-disabled="isDisabled">Baseline</button>
           <button mdc-button unelevated="true" compact="true" ng-disabled="isDisabled">Compact</button>
           <button mdc-button unelevated="true" dense="true" ng-disabled="isDisabled">Dense</button>
           <button mdc-button unelevated="true" class="secondary-filled-button" ng-disabled="isDisabled">Secondary</button>
           <button mdc-button unelevated="true" ng-disabled="isDisabled">
-            <mdc-icon class="mdc-button__icon">favorite</mdc-icon> Icon
+            <mdc-icon class="lmdc-button__icon">favorite</mdc-icon> Icon
           </button>
           <a mdc-button unelevated="true" href="javascript:void(0);" ng-disabled="isDisabled">
             Link
@@ -157,14 +157,14 @@
         </fieldset>
 
         <fieldset>
-          <legend class="mdc-typography--title">Stroked Button (Experimental)</legend>
+          <legend class="lmdc-typography--title">Stroked Button (Experimental)</legend>
 
           <button mdc-button stroked="true" ng-disabled="isDisabled">Baseline</button>
           <button mdc-button stroked="true" compact="true" ng-disabled="isDisabled">Compact</button>
           <button mdc-button stroked="true" dense="true" ng-disabled="isDisabled">Dense</button>
           <button mdc-button stroked="true" class="secondary-stroked-button" ng-disabled="isDisabled">Secondary</button>
           <button mdc-button stroked="true" ng-disabled="isDisabled">
-            <mdc-icon class="mdc-button__icon">favorite</mdc-icon> Icon
+            <mdc-icon class="lmdc-button__icon">favorite</mdc-icon> Icon
           </button>
           <a mdc-button stroked="true" href="javascript:void(0);" ng-disabled="isDisabled">
             Link
@@ -172,7 +172,7 @@
         </fieldset>
 
         <fieldset>
-          <legend class="mdc-typography--title">Custom Button (Experimental)</legend>
+          <legend class="lmdc-typography--title">Custom Button (Experimental)</legend>
 
           <button mdc-button unelevated="true" class="big-round-corner-button" ng-disabled="isDisabled">
             Corner Radius

--- a/demos/button.scss
+++ b/demos/button.scss
@@ -5,25 +5,25 @@
 @import "~@material/theme/color-palette";
 
 // button styling
-.mdc-button.secondary-text-button {
+.lmdc-button.secondary-text-button {
   @include mdc-button-ink-color($mdc-theme-secondary);
   @include mdc-states(secondary);
 }
 
-.mdc-button.secondary-filled-button {
+.lmdc-button.secondary-filled-button {
   @include mdc-button-filled-accessible($mdc-theme-secondary);
 }
 
-.mdc-button.secondary-stroked-button {
+.lmdc-button.secondary-stroked-button {
   @include mdc-button-ink-color($mdc-theme-secondary);
   @include mdc-button-stroke-color($mdc-theme-secondary);
   @include mdc-states(secondary);
 }
 
-.mdc-button.big-round-corner-button {
+.lmdc-button.big-round-corner-button {
   @include mdc-button-corner-radius(8px);
 }
 
-.mdc-button.thick-stroke-button {
+.lmdc-button.thick-stroke-button {
   @include mdc-button-stroke-width(4px);
 }

--- a/demos/card.html
+++ b/demos/card.html
@@ -34,48 +34,48 @@
 </head>
 
 <body ng-app="demo">
-  <header class="mdc-toolbar mdc-toolbar--fixed">
-    <div class="mdc-toolbar__row">
-      <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+  <header class="lmdc-toolbar lmdc-toolbar--fixed">
+    <div class="lmdc-toolbar__row">
+      <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
             <span class="catalog-back">
-              <a href="/" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+              <a href="/" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
             </span>
-        <span class="mdc-toolbar__title catalog-title">Card</span>
+        <span class="lmdc-toolbar__title catalog-title">Card</span>
       </section>
     </div>
   </header>
 
   <main ng-controller="MainCtrl" dir="{{ isRTL ? 'rtl' : '' }}">
-    <div class="mdc-toolbar-fixed-adjust"></div>
+    <div class="lmdc-toolbar-fixed-adjust"></div>
 
     <section class="hero">
-      <div class="mdc-card demo-card">
-        <div class="mdc-card__media mdc-card__media--16-9 demo-card__media demo-card__media--16-9"></div>
+      <div class="lmdc-card demo-card">
+        <div class="lmdc-card__media lmdc-card__media--16-9 demo-card__media demo-card__media--16-9"></div>
         <div class="demo-card__primary">
-          <h2 class="demo-card__title mdc-typography--title">Our Changing Planet</h2>
-          <h3 class="demo-card__subtitle mdc-typography--subheading1">by Kurt Wagner</h3>
+          <h2 class="demo-card__title lmdc-typography--title">Our Changing Planet</h2>
+          <h3 class="demo-card__subtitle lmdc-typography--subheading1">by Kurt Wagner</h3>
         </div>
-        <div class="demo-card__secondary mdc-typography--body1">
+        <div class="demo-card__secondary lmdc-typography--body1">
           Visit ten places on our planet that are undergoing the biggest changes today.
         </div>
-        <div class="mdc-card__actions">
-          <div class="mdc-card__action-buttons">
-            <button mdc-button class="mdc-card__action mdc-card__action--button">Read</button>
-            <button mdc-button class="mdc-card__action mdc-card__action--button">Bookmark</button>
+        <div class="lmdc-card__actions">
+          <div class="lmdc-card__action-buttons">
+            <button mdc-button class="lmdc-card__action lmdc-card__action--button">Read</button>
+            <button mdc-button class="lmdc-card__action lmdc-card__action--button">Bookmark</button>
           </div>
-          <div class="mdc-card__action-icons">
+          <div class="lmdc-card__action-icons">
             <mdc-icon-toggle
-                class="mdc-card__action mdc-card__action--icon"
+                class="lmdc-card__action lmdc-card__action--icon"
                 toggle-on='{"content": "favorite", "label": "Remove from favorites"}'
                 toggle-off='{"content": "favorite_border", "label": "Add to favorites"}'></mdc-icon-toggle>
             <mdc-icon
-                class="mdc-card__action mdc-card__action--icon"
+                class="lmdc-card__action lmdc-card__action--icon"
                 mdc-ripple data-mdc-ripple-is-unbounded
                 tabindex="0"
                 role="button"
                 title="Share">share</mdc-icon>
             <mdc-icon
-                class="mdc-card__action mdc-card__action--icon"
+                class="lmdc-card__action lmdc-card__action--icon"
                 mdc-ripple data-mdc-ripple-is-unbounded
                 tabindex="0"
                 role="button"
@@ -93,69 +93,69 @@
     </section>
 
     <section class="demo-card-collection">
-      <div class="mdc-card mdc-card--stroked demo-card">
-        <div class="demo-card-article-group-heading mdc-typography--subheading2">Headlines</div>
+      <div class="lmdc-card lmdc-card--stroked demo-card">
+        <div class="demo-card-article-group-heading lmdc-typography--subheading2">Headlines</div>
 
-        <hr class="mdc-list-divider">
+        <hr class="lmdc-list-divider">
 
-        <a class="demo-card-article mdc-ripple-surface" href="#">
-          <h2 class="demo-card-article__title mdc-typography--headline">Copper on the rise</h2>
-          <p class="demo-card-article__snippet mdc-typography--body1">
+        <a class="demo-card-article lmdc-ripple-surface" href="#">
+          <h2 class="demo-card-article__title lmdc-typography--headline">Copper on the rise</h2>
+          <p class="demo-card-article__snippet lmdc-typography--body1">
             Copper price soars amid global market optimism and increased demand.
           </p>
         </a>
 
-        <hr class="mdc-list-divider">
+        <hr class="lmdc-list-divider">
 
-        <a class="demo-card-article mdc-ripple-surface" href="#">
-          <h2 class="demo-card-article__title mdc-typography--headline">U.S. tech startups rebound</h2>
-          <p class="demo-card-article__snippet mdc-typography--body1">
+        <a class="demo-card-article lmdc-ripple-surface" href="#">
+          <h2 class="demo-card-article__title lmdc-typography--headline">U.S. tech startups rebound</h2>
+          <p class="demo-card-article__snippet lmdc-typography--body1">
             Favorable business conditions have allowed startups to secure more fundraising deals compared to last
             year.
           </p>
         </a>
 
-        <hr class="mdc-list-divider">
+        <hr class="lmdc-list-divider">
 
-        <a class="demo-card-article mdc-ripple-surface" href="#">
-          <h2 class="demo-card-article__title mdc-typography--headline">Asia's clean energy ambitions</h2>
-          <p class="demo-card-article__snippet mdc-typography--body1">
+        <a class="demo-card-article lmdc-ripple-surface" href="#">
+          <h2 class="demo-card-article__title lmdc-typography--headline">Asia's clean energy ambitions</h2>
+          <p class="demo-card-article__snippet lmdc-typography--body1">
             China plans to invest billions of dollars for the development of over 300 clean energy projects in
             Southeast Asia.
           </p>
         </a>
 
-        <hr class="mdc-list-divider">
+        <hr class="lmdc-list-divider">
 
-        <div class="mdc-card__actions mdc-card__actions--full-bleed">
-          <a class="mdc-button mdc-card__action mdc-card__action--button demo-card-action" href="#">
+        <div class="lmdc-card__actions lmdc-card__actions--full-bleed">
+          <a class="lmdc-button lmdc-card__action lmdc-card__action--button demo-card-action" href="#">
             All Business Headlines
             <i class="material-icons" aria-hidden="true">arrow_forward</i>
           </a>
         </div>
       </div>
 
-      <div class="mdc-card demo-card demo-card--photo">
-        <div class="mdc-card__media mdc-card__media--square demo-card__media">
-          <div class="mdc-card__media-content demo-card__media-content--with-title">
-            <div class="demo-card__media-title mdc-typography--subheading2">
+      <div class="lmdc-card demo-card demo-card--photo">
+        <div class="lmdc-card__media lmdc-card__media--square demo-card__media">
+          <div class="lmdc-card__media-content demo-card__media-content--with-title">
+            <div class="demo-card__media-title lmdc-typography--subheading2">
               Vacation Photos
             </div>
           </div>
         </div>
-        <div class="mdc-card__actions mdc-card__action-icons">
+        <div class="lmdc-card__actions lmdc-card__action-icons">
           <mdc-icon-toggle
-            class="mdc-card__action mdc-card__action--icon"
+            class="lmdc-card__action lmdc-card__action--icon"
             toggle-on='{"content": "favorite", "label": "Remove from favorites"}'
             toggle-off='{"content": "favorite_border", "label": "Add to favorites"}'>
           </mdc-icon-toggle>
           <mdc-icon-toggle
-              class="mdc-card__action mdc-card__action--icon"
+              class="lmdc-card__action lmdc-card__action--icon"
               toggle-on='{"content": "bookmark", "label": "Remove bookmark"}'
               toggle-off='{"content": "bookmark_border", "label": "Add bookmark"}'>
           </mdc-icon-toggle>
           <mdc-icon
-              class="mdc-card__action mdc-card__action--icon"
+              class="lmdc-card__action lmdc-card__action--icon"
               tabindex="0"
               mdc-ripple data-mdc-ripple-is-unbounded
               title="Share"
@@ -165,19 +165,19 @@
         </div>
       </div>
 
-      <div class="mdc-card demo-card demo-card--music">
+      <div class="lmdc-card demo-card demo-card--music">
         <div class="demo-card__music-row">
-          <div class="mdc-card__media mdc-card__media--square demo-card__media demo-card__media--music"></div>
+          <div class="lmdc-card__media lmdc-card__media--square demo-card__media demo-card__media--music"></div>
           <div class="demo-card__music-info">
-            <div class="demo-card__music-title mdc-typography--headline">Rozes</div>
-            <div class="demo-card__music-artist mdc-typography--body1">Under the Grave</div>
-            <div class="demo-card__music-year mdc-typography--body1">(2016)</div>
+            <div class="demo-card__music-title lmdc-typography--headline">Rozes</div>
+            <div class="demo-card__music-artist lmdc-typography--body1">Under the Grave</div>
+            <div class="demo-card__music-year lmdc-typography--body1">(2016)</div>
           </div>
         </div>
-        <hr class="mdc-list-divider">
-        <div class="mdc-card__actions">
-          <div class="mdc-card__action-buttons demo-card__action-buttons--text-only">Rate this album</div>
-          <div class="mdc-card__action-icons">
+        <hr class="lmdc-list-divider">
+        <div class="lmdc-card__actions">
+          <div class="lmdc-card__action-buttons demo-card__action-buttons--text-only">Rate this album</div>
+          <div class="lmdc-card__action-icons">
             <mdc-icon ng-repeat="num in [1, 2, 3, 4, 5]"
                 class="demo-card__action-icon--star"
                 role="button"

--- a/demos/checkbox.html
+++ b/demos/checkbox.html
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License
 -->
-<html class="mdc-typography">
+<html class="lmdc-typography">
   <head>
     <meta charset="utf-8">
     <title>Checkbox - Material Components Catalog</title>
@@ -26,18 +26,18 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
   </head>
   <body ng-app="demo" ng-controller="MainCtrl">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Checkbox</span>
+          <span class="lmdc-toolbar__title catalog-title">Checkbox</span>
         </section>
       </div>
     </header>
     <main>
-      <div class="mdc-toolbar-fixed-adjust"></div>
+      <div class="lmdc-toolbar-fixed-adjust"></div>
       <section class="hero">
         <mdc-form-field>
           <mdc-checkbox indeterminate="isIndeterminate" ng-disabled="isDisabled"></mdc-checkbox>

--- a/demos/common.scss
+++ b/demos/common.scss
@@ -44,7 +44,7 @@ fieldset {
   border: 0;
 }
 
-.mdc-toolbar {
+.lmdc-toolbar {
   a {
     color: #f0f0f0;
     text-decoration: none;

--- a/demos/dialog-demo-template.html
+++ b/demos/dialog-demo-template.html
@@ -5,7 +5,7 @@
   <mdc-dialog-header>
     <mdc-dialog-title id="mdc-dialog-title">This dialog was opened from a separate file</mdc-dialog-title>
   </mdc-dialog-header>
-  <mdc-dialog-body id="mdc-dialog-body" class="mdc-dialog__body--scrollable">
+  <mdc-dialog-body id="mdc-dialog-body" class="lmdc-dialog__body--scrollable">
     The body intentionally has a scrollbar, too, even though there's not a lot of content.
   </mdc-dialog-body>
   <mdc-dialog-footer>

--- a/demos/dialog.html
+++ b/demos/dialog.html
@@ -46,23 +46,23 @@
       }
     </style>
   </head>
-  <body class="mdc-typography" ng-app="demo" ng-controller="MainCtrl"
+  <body class="lmdc-typography" ng-app="demo" ng-controller="MainCtrl"
         dir="{{ isRTL ? 'rtl': ''}}">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Dialog</span>
+          <span class="lmdc-toolbar__title catalog-title">Dialog</span>
         </section>
       </div>
     </header>
     <main>
-      <div class="mdc-toolbar-fixed-adjust"></div>
+      <div class="lmdc-toolbar-fixed-adjust"></div>
       <section class="hero" dir="{{ isRTL ? 'rtl': ''}}">
-        <aside class="catalog-dialog-demo mdc-dialog mdc-dialog--open">
-      	  <div class="mdc-dialog__surface">
+        <aside class="catalog-dialog-demo lmdc-dialog lmdc-dialog--open">
+      	  <div class="lmdc-dialog__surface">
       	    <mdc-dialog-header>
       	      <mdc-dialog-title>
       	        Are you happy?

--- a/demos/elevation.html
+++ b/demos/elevation.html
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License
 -->
-<html class="mdc-typography">
+<html class="lmdc-typography">
   <head>
     <meta charset="utf-8">
     <title>Elevation - Material Components Catalog</title>
@@ -65,109 +65,109 @@
     </style>
   </head>
   <body ng-app="demo" ng-controller="MainCtrl">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Elevation</span>
+          <span class="lmdc-toolbar__title catalog-title">Elevation</span>
         </section>
       </div>
     </header>
     <main>
-      <div class="mdc-toolbar-fixed-adjust"></div>
+      <div class="lmdc-toolbar-fixed-adjust"></div>
       <section class="hero">
-        <figure class="demo-surface mdc-elevation--z0">
+        <figure class="demo-surface lmdc-elevation--z0">
           <figcaption>FLAT 0dp</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z4">
+        <figure class="demo-surface lmdc-elevation--z4">
           <figcaption>RAISED 4dp</figcaption>
         </figure>
       </section>
 
       <section class="demo-surfaces">
-        <figure class="demo-surface mdc-elevation--z0">
+        <figure class="demo-surface lmdc-elevation--z0">
           <figcaption>0dp (<code>mdc-elevation--z0</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z1">
+        <figure class="demo-surface lmdc-elevation--z1">
           <figcaption>1dp (<code>mdc-elevation--z1</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z2">
+        <figure class="demo-surface lmdc-elevation--z2">
           <figcaption>2dp (<code>mdc-elevation--z2</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z3">
+        <figure class="demo-surface lmdc-elevation--z3">
           <figcaption>3dp (<code>mdc-elevation--z3</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z4">
+        <figure class="demo-surface lmdc-elevation--z4">
           <figcaption>4dp (<code>mdc-elevation--z4</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z5">
+        <figure class="demo-surface lmdc-elevation--z5">
           <figcaption>5dp (<code>mdc-elevation--z5</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z6">
+        <figure class="demo-surface lmdc-elevation--z6">
           <figcaption>6dp (<code>mdc-elevation--z6</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z7">
+        <figure class="demo-surface lmdc-elevation--z7">
           <figcaption>7dp (<code>mdc-elevation--z7</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z8">
+        <figure class="demo-surface lmdc-elevation--z8">
           <figcaption>8dp (<code>mdc-elevation--z8</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z9">
+        <figure class="demo-surface lmdc-elevation--z9">
           <figcaption>9dp (<code>mdc-elevation--z9</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z10">
+        <figure class="demo-surface lmdc-elevation--z10">
           <figcaption>10dp (<code>mdc-elevation--z10</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z11">
+        <figure class="demo-surface lmdc-elevation--z11">
           <figcaption>11dp (<code>mdc-elevation--z11</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z12">
+        <figure class="demo-surface lmdc-elevation--z12">
           <figcaption>12dp (<code>mdc-elevation--z12</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z13">
+        <figure class="demo-surface lmdc-elevation--z13">
           <figcaption>13dp (<code>mdc-elevation--z13</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z14">
+        <figure class="demo-surface lmdc-elevation--z14">
           <figcaption>14dp (<code>mdc-elevation--z14</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z15">
+        <figure class="demo-surface lmdc-elevation--z15">
           <figcaption>15dp (<code>mdc-elevation--z15</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z16">
+        <figure class="demo-surface lmdc-elevation--z16">
           <figcaption>16dp (<code>mdc-elevation--z16</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z17">
+        <figure class="demo-surface lmdc-elevation--z17">
           <figcaption>17dp (<code>mdc-elevation--z17</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z18">
+        <figure class="demo-surface lmdc-elevation--z18">
           <figcaption>18dp (<code>mdc-elevation--z18</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z19">
+        <figure class="demo-surface lmdc-elevation--z19">
           <figcaption>19dp (<code>mdc-elevation--z19</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z20">
+        <figure class="demo-surface lmdc-elevation--z20">
           <figcaption>20dp (<code>mdc-elevation--z20</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z21">
+        <figure class="demo-surface lmdc-elevation--z21">
           <figcaption>21dp (<code>mdc-elevation--z21</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z22">
+        <figure class="demo-surface lmdc-elevation--z22">
           <figcaption>22dp (<code>mdc-elevation--z22</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z23">
+        <figure class="demo-surface lmdc-elevation--z23">
           <figcaption>23dp (<code>mdc-elevation--z23</code>)</figcaption>
         </figure>
-        <figure class="demo-surface mdc-elevation--z24">
+        <figure class="demo-surface lmdc-elevation--z24">
           <figcaption>24dp (<code>mdc-elevation--z24</code>)</figcaption>
         </figure>
       </section>
       <section>
-        <div ng-class="{'mdc-elevation--z2': !hover, 'mdc-elevation--z8': hover}"
+        <div ng-class="{'lmdc-elevation--z2': !hover, 'lmdc-elevation--z8': hover}"
              ng-mouseenter="hover = true" ng-mouseleave="hover = false"
              id="hover-el"
-             class="mdc-elevation-transition">
+             class="lmdc-elevation-transition">
           <p>Hover over or tap me for a transition</p>
         </div>
       </section>

--- a/demos/experimental/tabs.html
+++ b/demos/experimental/tabs.html
@@ -122,18 +122,18 @@ limitations under the License
     </style>
   </head>
   <body ng-app="demo">
-    <header class="mdc-toolbar mdc-toolbar--fixed demo-header-toolbar">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed demo-header-toolbar">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="../" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="../" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Tabs</span>
+          <span class="lmdc-toolbar__title catalog-title">Tabs</span>
         </section>
       </div>
     </header>
 
-    <main ng-controller="MainCtrl" dir="{{ isRTL ? 'rtl' : '' }}" class="mdc-toolbar-fixed-adjust">
+    <main ng-controller="MainCtrl" dir="{{ isRTL ? 'rtl' : '' }}" class="lmdc-toolbar-fixed-adjust">
       <section class="hero">
         <mdc-tab-bar>
           <mdc-tab>Item One</mdc-tab>
@@ -148,12 +148,12 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Basic Tab Bar w/ Dropdown</legend>
+          <legend class="lmdc-typography--title">Basic Tab Bar w/ Dropdown</legend>
           <mdc-tab-bar ng-model="withmenu" class="custom-label-color-tab">
             <mdc-tab ng-value="1">Item One</mdc-tab>
             <mdc-tab ng-value="2">Item Two</mdc-tab>
             <mdc-tab>
-              More <mdc-icon class="mdc-tab__drop-down-icon">arrow_drop_down</mdc-icon>
+              More <mdc-icon class="lmdc-tab__drop-down-icon">arrow_drop_down</mdc-icon>
               <mdc-menu>
                 <mdc-menu-item ng-value="3">Item Three</mdc-menu-item>
                 <mdc-menu-item ng-value="4">Item Four</mdc-menu-item>
@@ -166,12 +166,12 @@ limitations under the License
 
       <section>
         <div class="demo-tabs__scroller">
-          <h2 class="mdc-typography--title demo-title">Tab Bar w/ Scroller & Dropdown</h2>
+          <h2 class="lmdc-typography--title demo-title">Tab Bar w/ Scroller & Dropdown</h2>
           <mdc-tab-bar-scroller>
             <mdc-tab-bar>
               <mdc-tab ng-repeat="tab in [1,2,3,4,5,6]">Item {{ tab }}</mdc-tab>
               <mdc-tab>
-                Items 7,8,9 <mdc-icon class="mdc-tab__drop-down-icon">arrow_drop_down</mdc-icon>
+                Items 7,8,9 <mdc-icon class="lmdc-tab__drop-down-icon">arrow_drop_down</mdc-icon>
                 <mdc-menu>
                   <mdc-menu-item ng-repeat="item in [7,8,9]">Item {{ item }}</mdc-menu-item>
                 </mdc-menu>
@@ -184,7 +184,7 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Basic Tab Bar</legend>
+          <legend class="lmdc-typography--title">Basic Tab Bar</legend>
           <mdc-tab-bar ng-model="cycleSelect">
             <mdc-tab ng-value="0">Item One</mdc-tab>
             <mdc-tab ng-value="1">Item Two</mdc-tab>
@@ -197,7 +197,7 @@ limitations under the License
       </section>
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Basic Tab Bar w/ Custom Label Color</legend>
+          <legend class="lmdc-typography--title">Basic Tab Bar w/ Custom Label Color</legend>
           <mdc-tab-bar ng-model="clicked" class="custom-label-color-tab">
             <mdc-tab ng-value="undefined">One (undefined)</mdc-tab>
             <mdc-tab ng-value="'Two'">Two ("Two")</mdc-tab>
@@ -211,7 +211,7 @@ limitations under the License
 
       <section>
         <div class="demo-tabs__scroller">
-          <h2 class="mdc-typography--title demo-title">Tab Bar with Scroller</h2>
+          <h2 class="lmdc-typography--title demo-title">Tab Bar with Scroller</h2>
           <mdc-tab-bar-scroller>
             <mdc-tab-bar ng-model="scroll.selected" ng-if="demoToggled">
               <mdc-tab ng-repeat="num in numbers" value="{{ $index + 1 }}">Item {{ num }}</mdc-tab>
@@ -225,16 +225,16 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Icon Tab Labels</legend>
+          <legend class="lmdc-typography--title">Icon Tab Labels</legend>
           <mdc-tab-bar variant="icon" ng-if="demoToggled">
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-label="Recents">phone</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-label="Recents">phone</mdc-icon>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-label="Favorites">favorite</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-label="Favorites">favorite</mdc-icon>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-label="nearby">person_pin</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-label="nearby">person_pin</mdc-icon>
             </mdc-tab>
           </mdc-tab-bar>
         </fieldset>
@@ -242,16 +242,16 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Icon Tab Labels w/ Custom Icon Color</legend>
+          <legend class="lmdc-typography--title">Icon Tab Labels w/ Custom Icon Color</legend>
           <mdc-tab-bar variant="icon" class="custom-icon-color-tab" ng-if="demoToggled">
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-label="Recents">phone</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-label="Recents">phone</mdc-icon>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-label="Favorites">favorite</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-label="Favorites">favorite</mdc-icon>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-label="nearby">person_pin</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-label="nearby">person_pin</mdc-icon>
             </mdc-tab>
           </mdc-tab-bar>
         </fieldset>
@@ -259,18 +259,18 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Icon &amp; Text Labels</legend>
+          <legend class="lmdc-typography--title">Icon &amp; Text Labels</legend>
           <mdc-tab-bar variant="icons-text">
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-hidden="true">phone</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-hidden="true">phone</mdc-icon>
               <mdc-tab-text>Recents</mdc-tab-text>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-hidden="true">favorite</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-hidden="true">favorite</mdc-icon>
               <mdc-tab-text>Favorites</mdc-tab-text>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-hidden="true">person_pin</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-hidden="true">person_pin</mdc-icon>
               <mdc-tab-text>Nearby</mdc-tab-text>
             </mdc-tab>
           </mdc-tab-bar>
@@ -279,18 +279,18 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Icon &amp; Text Labels w/ Custom Colors</legend>
+          <legend class="lmdc-typography--title">Icon &amp; Text Labels w/ Custom Colors</legend>
           <mdc-tab-bar variant="icons-text" class="custom-ink-color-tab">
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-hidden="true">phone</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-hidden="true">phone</mdc-icon>
               <mdc-tab-text>Recents</mdc-tab-text>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-hidden="true">favorite</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-hidden="true">favorite</mdc-icon>
               <mdc-tab-text>Favorites</mdc-tab-text>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-hidden="true">person_pin</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-hidden="true">person_pin</mdc-icon>
               <mdc-tab-text>Nearby</mdc-tab-text>
             </mdc-tab>
           </mdc-tab-bar>
@@ -299,7 +299,7 @@ limitations under the License
 
       <section>
         <div class="demo-tabs__scroller">
-          <h2 class="mdc-typography--title demo-title">Custom Indicator Color</h2>
+          <h2 class="lmdc-typography--title demo-title">Custom Indicator Color</h2>
           <mdc-tab-bar-scroller>
             <mdc-tab-bar class="custom-indicator-tab-bar" ng-model="mutable.sel" ng-if="demoToggled">
               <mdc-tab ng-repeat="item in mutable.list"
@@ -317,13 +317,13 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Within mdc-toolbar</legend>
-          <div class="mdc-toolbar">
-            <div class="mdc-toolbar__row">
-              <div class="mdc-toolbar__section mdc-toolbar__section--shrink-to-fit mdc-toolbar__section--align-start">
-                <h2 class="mdc-toolbar__title">Title</h2>
+          <legend class="lmdc-typography--title">Within mdc-toolbar</legend>
+          <div class="lmdc-toolbar">
+            <div class="lmdc-toolbar__row">
+              <div class="lmdc-toolbar__section lmdc-toolbar__section--shrink-to-fit lmdc-toolbar__section--align-start">
+                <h2 class="lmdc-toolbar__title">Title</h2>
               </div>
-              <div class="mdc-toolbar__section mdc-toolbar__section--align-end">
+              <div class="lmdc-toolbar__section lmdc-toolbar__section--align-end">
                 <div>
                   <mdc-tab-bar class="custom-tab-bar-in-toolbar">
                     <mdc-tab>Item One</mdc-tab>
@@ -339,7 +339,7 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Within MDCToolbar - fixed to bottom of toolbar</legend>
+          <legend class="lmdc-typography--title">Within MDCToolbar - fixed to bottom of toolbar</legend>
           <div class="demo-note">
             <em>
               Note: We want to avoid too many modifier classes for layouts like this. Therefore, we recommend overriding the style of
@@ -362,12 +362,12 @@ limitations under the License
             </code>
           </pre>
           </div>
-          <div class="mdc-toolbar">
-            <div class="mdc-toolbar__row">
-              <div class="mdc-toolbar__section mdc-toolbar__section--shrink-to-fit mdc-toolbar__section--align-start">
-                <h1 class="mdc-toolbar__title">Title</h1>
+          <div class="lmdc-toolbar">
+            <div class="lmdc-toolbar__row">
+              <div class="lmdc-toolbar__section lmdc-toolbar__section--shrink-to-fit lmdc-toolbar__section--align-start">
+                <h1 class="lmdc-toolbar__title">Title</h1>
               </div>
-              <div class="mdc-toolbar__section my-modified-toolbar-section">
+              <div class="lmdc-toolbar__section my-modified-toolbar-section">
                 <mdc-tab-bar class="custom-tab-bar-in-toolbar">
                   <mdc-tab>Item One</mdc-tab>
                   <mdc-tab>Item Two</mdc-tab>
@@ -381,16 +381,16 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Within mdc-toolbar + custom color indicator</legend>
+          <legend class="lmdc-typography--title">Within mdc-toolbar + custom color indicator</legend>
           <div class="demo-note">
             <em>Note: Changing the toolbar's background color here so that the primary indicator can be visible</em>
           </div>
-          <div class="mdc-toolbar mdc-theme--accent-bg">
-            <div class="mdc-toolbar__row">
-              <div class="mdc-toolbar__section mdc-toolbar__section--shrink-to-fit mdc-toolbar__section--align-start">
-                <h1 class="mdc-toolbar__title">Title</h1>
+          <div class="lmdc-toolbar lmdc-theme--accent-bg">
+            <div class="lmdc-toolbar__row">
+              <div class="lmdc-toolbar__section lmdc-toolbar__section--shrink-to-fit lmdc-toolbar__section--align-start">
+                <h1 class="lmdc-toolbar__title">Title</h1>
               </div>
-              <div class="mdc-toolbar__section mdc-toolbar__section--align-end">
+              <div class="lmdc-toolbar__section lmdc-toolbar__section--align-end">
                 <div>
                   <mdc-tab-bar class="custom-indicator-tab-bar-in-toolbar">
                     <mdc-tab>Item One</mdc-tab>
@@ -406,10 +406,10 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Within Toolbar, Dynamic Content Control</legend>
-          <div class="mdc-toolbar" id="dynamic-demo-toolbar">
-            <div class="mdc-toolbar__row">
-              <div class="mdc-toolbar__section mdc-toolbar__section--align-start">
+          <legend class="lmdc-typography--title">Within Toolbar, Dynamic Content Control</legend>
+          <div class="lmdc-toolbar" id="dynamic-demo-toolbar">
+            <div class="lmdc-toolbar__row">
+              <div class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
                 <mdc-tab-bar ng-model="selectedTab" class="custom-indicator-tab-bar-in-toolbar">
                   <mdc-tab ng-value="0">Item One</mdc-tab>
                   <mdc-tab ng-value="1">Item Two</mdc-tab>

--- a/demos/grid-list.html
+++ b/demos/grid-list.html
@@ -41,7 +41,7 @@
         background-color: white;
       }
 
-      .hero .mdc-grid-tile__primary {
+      .hero .lmdc-grid-tile__primary {
         background-color: #212121;
       }
 
@@ -50,23 +50,23 @@
       }
     </style>
   </head>
-  <body class="mdc-typography mdc-grid-list-demo" ng-app="demo">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+  <body class="lmdc-typography lmdc-grid-list-demo" ng-app="demo">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Grid List</span>
+          <span class="lmdc-toolbar__title catalog-title">Grid List</span>
         </section>
       </div>
     </header>
     <main ng-controller="MainCtrl">
-      <div class="mdc-toolbar-fixed-adjust"></div>
+      <div class="lmdc-toolbar-fixed-adjust"></div>
       <section class="hero">
         <mdc-grid-list>
           <mdc-grid-tile ng-repeat="i in twelve">
-            <div class="mdc-grid-tile__primary"></div>
+            <div class="lmdc-grid-tile__primary"></div>
           </mdc-grid-tile>
         </mdc-grid-list>
       </section>
@@ -85,114 +85,114 @@
         <h2>Grid List (Default): tile aspect ratio 1x1 with oneline footer caption</h2>
         <mdc-grid-list>
             <mdc-grid-tile ng-repeat="i in six">
-              <div class="mdc-grid-tile__primary">
-                <img class="mdc-grid-tile__primary-content" src="images/1-1.jpg" />
+              <div class="lmdc-grid-tile__primary">
+                <img class="lmdc-grid-tile__primary-content" src="images/1-1.jpg" />
               </div>
-              <span class="mdc-grid-tile__secondary">
-                <span class="mdc-grid-tile__title">Single Very Long Grid Title Line</span>
+              <span class="lmdc-grid-tile__secondary">
+                <span class="lmdc-grid-tile__title">Single Very Long Grid Title Line</span>
               </span>
             </mdc-grid-tile>
         </mdc-grid-list>
         <h2>Grid List: tile aspect ratio 1x1 with 1px gutter</h2>
         <mdc-grid-list gutter="1">
           <mdc-grid-tile ng-repeat="i in six">
-            <div class="mdc-grid-tile__primary">
-              <img class="mdc-grid-tile__primary-content" src="images/1-1.jpg" />
+            <div class="lmdc-grid-tile__primary">
+              <img class="lmdc-grid-tile__primary-content" src="images/1-1.jpg" />
             </div>
-            <span class="mdc-grid-tile__secondary">
-              <span class="mdc-grid-tile__title">Single Very Long Grid Title Line</span>
+            <span class="lmdc-grid-tile__secondary">
+              <span class="lmdc-grid-tile__title">Single Very Long Grid Title Line</span>
             </span>
           </mdc-grid-tile>
         </mdc-grid-list>
         <h2>Grid List: tile aspect ratio 1x1 image only</h2>
         <mdc-grid-list>
           <mdc-grid-tile ng-repeat="i in six">
-            <div class="mdc-grid-tile__primary">
-              <img class="mdc-grid-tile__primary-content" src="images/1-1.jpg" />
+            <div class="lmdc-grid-tile__primary">
+              <img class="lmdc-grid-tile__primary-content" src="images/1-1.jpg" />
             </div>
           </mdc-grid-tile>
         </mdc-grid-list>
         <h2>Grid List: tile aspect ratio 1x1 with oneline header caption</h2>
-        <mdc-grid-list class="mdc-grid-list--header-caption">
+        <mdc-grid-list class="lmdc-grid-list--header-caption">
           <mdc-grid-tile ng-repeat="i in six">
-            <div class="mdc-grid-tile__primary">
-              <img class="mdc-grid-tile__primary-content" src="images/1-1.jpg" />
+            <div class="lmdc-grid-tile__primary">
+              <img class="lmdc-grid-tile__primary-content" src="images/1-1.jpg" />
             </div>
-            <span class="mdc-grid-tile__secondary">
-              <span class="mdc-grid-tile__title">Single Very Long Grid Title Line</span>
+            <span class="lmdc-grid-tile__secondary">
+              <span class="lmdc-grid-tile__title">Single Very Long Grid Title Line</span>
             </span>
           </mdc-grid-tile>
         </mdc-grid-list>
         <h2>Grid List: tile aspect ratio 1x1 with twoline footer caption</h2>
-        <mdc-grid-list class="mdc-grid-list--twoline-caption">
+        <mdc-grid-list class="lmdc-grid-list--twoline-caption">
           <mdc-grid-tile ng-repeat="i in six">
-            <div class="mdc-grid-tile__primary">
-              <img class="mdc-grid-tile__primary-content" src="images/1-1.jpg" />
+            <div class="lmdc-grid-tile__primary">
+              <img class="lmdc-grid-tile__primary-content" src="images/1-1.jpg" />
             </div>
-            <span class="mdc-grid-tile__secondary">
-              <span class="mdc-grid-tile__title">Single Very Long Grid Title Line</span>
-              <span class="mdc-grid-tile__support-text">Support text that is really really long</span>
+            <span class="lmdc-grid-tile__secondary">
+              <span class="lmdc-grid-tile__title">Single Very Long Grid Title Line</span>
+              <span class="lmdc-grid-tile__support-text">Support text that is really really long</span>
             </span>
           </mdc-grid-tile>
         </mdc-grid-list>
         <h2>Grid List: tile aspect ratio 1x1 with oneline footer caption and icon at start of the caption</h2>
         <mdc-grid-list icon-align="start">
           <mdc-grid-tile ng-repeat="i in six">
-            <div class="mdc-grid-tile__primary">
-              <img class="mdc-grid-tile__primary-content" src="images/1-1.jpg" />
+            <div class="lmdc-grid-tile__primary">
+              <img class="lmdc-grid-tile__primary-content" src="images/1-1.jpg" />
             </div>
-            <span class="mdc-grid-tile__secondary">
+            <span class="lmdc-grid-tile__secondary">
               <mdc-icon>star_border</mdc-icon>
-              <span class="mdc-grid-tile__title">Single Very Long Grid Title Line</span>
+              <span class="lmdc-grid-tile__title">Single Very Long Grid Title Line</span>
             </span>
           </mdc-grid-tile>
         </mdc-grid-list>
         <h2>Grid List: tile aspect ratio 1x1 with twoline footer caption and icon at start of the caption</h2>
-        <mdc-grid-list icon-align="start" class="mdc-grid-list--twoline-caption">
+        <mdc-grid-list icon-align="start" class="lmdc-grid-list--twoline-caption">
           <mdc-grid-tile ng-repeat="i in six">
-            <div class="mdc-grid-tile__primary">
-              <img class="mdc-grid-tile__primary-content" src="images/1-1.jpg" />
+            <div class="lmdc-grid-tile__primary">
+              <img class="lmdc-grid-tile__primary-content" src="images/1-1.jpg" />
             </div>
-            <span class="mdc-grid-tile__secondary">
+            <span class="lmdc-grid-tile__secondary">
               <mdc-icon>star_border</mdc-icon>
-              <span class="mdc-grid-tile__title">Single Very Long Grid Title Line</span>
-              <span class="mdc-grid-tile__support-text">Support text</span>
+              <span class="lmdc-grid-tile__title">Single Very Long Grid Title Line</span>
+              <span class="lmdc-grid-tile__support-text">Support text</span>
             </span>
           </mdc-grid-tile>
         </mdc-grid-list>
         <h2>Grid List: tile aspect ratio 1x1 with oneline footer caption and icon at end of the caption</h2>
         <mdc-grid-list icon-align="end">
           <mdc-grid-tile ng-repeat="i in six">
-            <div class="mdc-grid-tile__primary">
-              <img class="mdc-grid-tile__primary-content" src="images/1-1.jpg" />
+            <div class="lmdc-grid-tile__primary">
+              <img class="lmdc-grid-tile__primary-content" src="images/1-1.jpg" />
             </div>
-            <span class="mdc-grid-tile__secondary">
+            <span class="lmdc-grid-tile__secondary">
               <mdc-icon>star_border</mdc-icon>
-              <span class="mdc-grid-tile__title">Single Very Long Grid Title Line</span>
+              <span class="lmdc-grid-tile__title">Single Very Long Grid Title Line</span>
             </span>
           </mdc-grid-tile>
         </mdc-grid-list>
         <h2>Grid List: tile aspect ratio 1x1 with twoline footer caption and icon at end of the caption</h2>
-        <mdc-grid-list icon-align="end" class="mdc-grid-list--twoline-caption">
+        <mdc-grid-list icon-align="end" class="lmdc-grid-list--twoline-caption">
           <mdc-grid-tile ng-repeat="i in six">
-            <div class="mdc-grid-tile__primary">
-              <img class="mdc-grid-tile__primary-content" src="images/1-1.jpg" />
+            <div class="lmdc-grid-tile__primary">
+              <img class="lmdc-grid-tile__primary-content" src="images/1-1.jpg" />
             </div>
-            <span class="mdc-grid-tile__secondary">
+            <span class="lmdc-grid-tile__secondary">
               <mdc-icon>star_border</mdc-icon>
-              <span class="mdc-grid-tile__title">Single Very Long Grid Title Line</span>
-              <span class="mdc-grid-tile__support-text">Support text</span>
+              <span class="lmdc-grid-tile__title">Single Very Long Grid Title Line</span>
+              <span class="lmdc-grid-tile__support-text">Support text</span>
             </span>
           </mdc-grid-tile>
         </mdc-grid-list>
         <h2>Grid List: use div's background instead of img tag (useful when image ratio cannot be ensured)</h2>
-        <mdc-grid-list class="mdc-grid-list--header-caption">
+        <mdc-grid-list class="lmdc-grid-list--header-caption">
           <mdc-grid-tile ng-repeat="i in six">
-            <div class="mdc-grid-tile__primary">
-              <div class="mdc-grid-tile__primary-content demo-grid-tile-content"></div>
+            <div class="lmdc-grid-tile__primary">
+              <div class="lmdc-grid-tile__primary-content demo-grid-tile-content"></div>
             </div>
-            <span class="mdc-grid-tile__secondary">
-              <span class="mdc-grid-tile__title">Single Very Long Grid Title Line</span>
+            <span class="lmdc-grid-tile__secondary">
+              <span class="lmdc-grid-tile__title">Single Very Long Grid Title Line</span>
             </span>
           </mdc-grid-tile>
         </mdc-grid-list>
@@ -201,11 +201,11 @@
         </h2>
         <mdc-grid-list aspect="{{ aspect }}" ng-repeat-end>
           <mdc-grid-tile ng-repeat="i in six">
-            <div class="mdc-grid-tile__primary">
-              <img class="mdc-grid-tile__primary-content" src="images/16-9.jpg" />
+            <div class="lmdc-grid-tile__primary">
+              <img class="lmdc-grid-tile__primary-content" src="images/16-9.jpg" />
             </div>
-            <span class="mdc-grid-tile__secondary">
-              <span class="mdc-grid-tile__title">Single Very Long Grid Title Line</span>
+            <span class="lmdc-grid-tile__secondary">
+              <span class="lmdc-grid-tile__title">Single Very Long Grid Title Line</span>
             </span>
           </mdc-grid-tile>
         </mdc-grid-list>

--- a/demos/icon-toggle.html
+++ b/demos/icon-toggle.html
@@ -11,7 +11,7 @@
   See the License for the specific language governing permissions and
   limitations under the License
   -->
-<html class="mdc-typography">
+<html class="lmdc-typography">
   <head>
     <meta charset="utf-8">
     <title>Icon Toggle - Material Components Demo</title>
@@ -73,18 +73,18 @@
     </style>
   </head>
   <body ng-app="demo">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Icon Toggle</span>
+          <span class="lmdc-toolbar__title catalog-title">Icon Toggle</span>
         </section>
       </div>
     </header>
-    <main class="mdc-toolbar-fixed-adjust" ng-controller="MainCtrl">
-      <div class="mdc-toolbar-fixed-adjust"></div>
+    <main class="lmdc-toolbar-fixed-adjust" ng-controller="MainCtrl">
+      <div class="lmdc-toolbar-fixed-adjust"></div>
       <section class="hero">
         <div>
           <div class="demo-wrapper">
@@ -148,15 +148,15 @@
           <div id="demo-color-combos">
             <div id="light-on-bg" class="demo-color-combo">
               <div>
-                <mdc-icon-toggle class="mdc-theme--text-primary-on-primary" tabindex="0"
+                <mdc-icon-toggle class="lmdc-theme--text-primary-on-primary" tabindex="0"
                                  toggle-on='{"content": "favorite", "label": "Remove From Favorites"}'
                                  toggle-off='{"content": "favorite_border", "label": "Add to Favorites"}'>
                 </mdc-icon-toggle>
               </div>
-              <p class="mdc-theme--text-primary-on-primary">Light icon on background</p>
+              <p class="lmdc-theme--text-primary-on-primary">Light icon on background</p>
             </div>
             <div id="dark-on-bg" class="demo-color-combo">
-              <div class="mdc-theme--primary">
+              <div class="lmdc-theme--primary">
                 <mdc-icon-toggle tabindex="0"
                                  toggle-on='{"content": "favorite", "label": "Remove From Favorites"}'
                                  toggle-off='{"content": "favorite_border", "label": "Add to Favorites"}'>

--- a/demos/icon-toggle.scss
+++ b/demos/icon-toggle.scss
@@ -4,7 +4,7 @@
 #light-on-bg {
   background-color: #3e82f7;
 }
-#light-on-bg .mdc-icon-toggle {
+#light-on-bg .lmdc-icon-toggle {
   @include mdc-icon-toggle-ink-color(white);
   @include mdc-states-base-color(white);
   @include mdc-states-hover-opacity(.1);
@@ -15,12 +15,12 @@
 #dark-on-bg {
   background-color: #00bcd6;
 }
-#dark-on-bg .mdc-icon-toggle {
+#dark-on-bg .lmdc-icon-toggle {
   @include mdc-icon-toggle-ink-color(black);
   @include mdc-states(black);
 }
 
-#custom-on-dark .mdc-icon-toggle {
+#custom-on-dark .lmdc-icon-toggle {
   @include mdc-icon-toggle-ink-color(#de442c);
   @include mdc-states-base-color(#de442c);
   @include mdc-states-hover-opacity(.09);

--- a/demos/icon.html
+++ b/demos/icon.html
@@ -52,17 +52,17 @@
     </style>
   </head>
   <body ng-app="demo">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Icons</span>
+          <span class="lmdc-toolbar__title catalog-title">Icons</span>
         </section>
       </div>
     </header>
-    <main class="mdc-toolbar-fixed-adjust" ng-controller="MainCtrl">
+    <main class="lmdc-toolbar-fixed-adjust" ng-controller="MainCtrl">
 
       <section class="hero">
         <div>
@@ -74,7 +74,7 @@
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Using html context</legend>
+          <legend class="lmdc-typography--title">Using html context</legend>
           <div class="glyph-row" ng-repeat="icon in iconSets[2]">
             <div class="preview-glyphs" ng-repeat="size in sizes">
               <mdc-icon ng-style="{color: icon.color}"

--- a/demos/index.html
+++ b/demos/index.html
@@ -25,217 +25,217 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
-  <body ng-app="demo" class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
-          <span class="catalog-logo mdc-toolbar__menu-icon">
+  <body ng-app="demo" class="lmdc-typography">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
+          <span class="catalog-logo lmdc-toolbar__menu-icon">
             <img src="images/ic_component_24px_white.svg">
           </span>
-          <span class="mdc-toolbar__title catalog-title">Material Components Catalog</span>
+          <span class="lmdc-toolbar__title catalog-title">Material Components Catalog</span>
         </section>
       </div>
     </header>
     <main>
-      <nav class="mdc-toolbar-fixed-adjust">
+      <nav class="lmdc-toolbar-fixed-adjust">
         <mdc-list two-line="true" class="demo-catalog-list">
 
           <!-- Button -->
           <a mdc-list-item href="button.html">
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><mdc-icon>add_circle_outline</mdc-icon></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><mdc-icon>add_circle_outline</mdc-icon></span>
+            <span class="lmdc-list-item__text">
               Button
-              <span class="mdc-list-item__secondary-text">Raised and flat buttons</span>
+              <span class="lmdc-list-item__secondary-text">Raised and flat buttons</span>
             </span>
           </a>
 
 
           <!-- Card -->
           <a mdc-list-item href="card.html">
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_card_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_card_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Card
-              <span class="mdc-list-item__secondary-text">Various card layout styles</span>
+              <span class="lmdc-list-item__secondary-text">Various card layout styles</span>
             </span>
           </a>
 
 
           <!-- Checkbox -->
           <a mdc-list-item href="checkbox.html" >
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_selection_control_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_selection_control_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Checkbox
-              <span class="mdc-list-item__secondary-text">Multi-selection controls</span>
+              <span class="lmdc-list-item__secondary-text">Multi-selection controls</span>
             </span>
           </a>
 
 
           <!-- Dialog -->
           <a mdc-list-item href="dialog.html">
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_dialog_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_dialog_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Dialog
-              <span class="mdc-list-item__secondary-text">Secondary text</span>
+              <span class="lmdc-list-item__secondary-text">Secondary text</span>
             </span>
           </a>
 
 
           <!-- Elevation -->
           <a mdc-list-item href="elevation.html">
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_shadow_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_shadow_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Elevation
-              <span class="mdc-list-item__secondary-text">Shadow for different elevations</span>
+              <span class="lmdc-list-item__secondary-text">Shadow for different elevations</span>
             </span>
           </a>
 
 
           <!-- Grid list -->
           <a mdc-list-item href="grid-list.html">
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_card_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_card_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Grid list
-              <span class="mdc-list-item__secondary-text">2D grid layouts</span>
+              <span class="lmdc-list-item__secondary-text">2D grid layouts</span>
             </span>
           </a>
 
 
           <!-- Icon -->
           <a mdc-list-item href="icon.html">
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><mdc-icon>insert_emoticon</mdc-icon></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><mdc-icon>insert_emoticon</mdc-icon></span>
+            <span class="lmdc-list-item__text">
               Icon
-              <span class="mdc-list-item__secondary-text">Material Design Icons</span>
+              <span class="lmdc-list-item__secondary-text">Material Design Icons</span>
             </span>
           </a>
 
 
           <!-- Icon toggle -->
           <a mdc-list-item href="icon-toggle.html">
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_component_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_component_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Icon toggle
-              <span class="mdc-list-item__secondary-text">Toggling icon states</span>
+              <span class="lmdc-list-item__secondary-text">Toggling icon states</span>
             </span>
           </a>
 
 
           <!-- List -->
           <a href="list.html" mdc-list-item>
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><mdc-icon>view_list</mdc-icon></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><mdc-icon>view_list</mdc-icon></span>
+            <span class="lmdc-list-item__text">
               List
-              <span class="mdc-list-item__secondary-text">Item layouts in lists</span>
+              <span class="lmdc-list-item__secondary-text">Item layouts in lists</span>
             </span>
           </a>
 
 
           <!-- Menu -->
           <a href="menu.html" mdc-list-item>
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_menu_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_menu_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Menu
-              <span class="mdc-list-item__secondary-text">Pop over menus</span>
+              <span class="lmdc-list-item__secondary-text">Pop over menus</span>
             </span>
           </a>
 
 
           <!-- Radio buttons -->
           <a mdc-list-item href="radio.html">
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><mdc-icon>radio_button_checked</mdc-icon></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><mdc-icon>radio_button_checked</mdc-icon></span>
+            <span class="lmdc-list-item__text">
               Radio buttons
-              <span class="mdc-list-item__secondary-text">Single selection controls</span>
+              <span class="lmdc-list-item__secondary-text">Single selection controls</span>
             </span>
           </a>
 
 
           <!-- Ripple -->
           <a href="ripple.html" mdc-list-item>
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_ripple_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_ripple_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Ripple
-              <span class="mdc-list-item__secondary-text">Touch ripple</span>
+              <span class="lmdc-list-item__secondary-text">Touch ripple</span>
             </span>
           </a>
 
 
           <!-- Select -->
           <a href="select.html" mdc-list-item>
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_menu_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_menu_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Select
-              <span class="mdc-list-item__secondary-text">Popover selection menus</span>
+              <span class="lmdc-list-item__secondary-text">Popover selection menus</span>
             </span>
           </a>
 
 
           <!-- Snackbar -->
           <a href="snackbar.html" mdc-list-item>
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_toast_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_toast_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Snackbar
-              <span class="mdc-list-item__secondary-text">Transient messages</span>
+              <span class="lmdc-list-item__secondary-text">Transient messages</span>
             </span>
           </a>
 
 
           <!-- Switch -->
           <a href="switch.html" mdc-list-item>
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_switch_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_switch_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Switch
-              <span class="mdc-list-item__secondary-text">On off switches</span>
+              <span class="lmdc-list-item__secondary-text">On off switches</span>
             </span>
           </a>
 
 
           <!-- Tabs -->
           <a href="tabs.html" mdc-list-item>
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_tabs_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_tabs_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Tabs
-              <span class="mdc-list-item__secondary-text">Tabs with support for icon and text labels</span>
+              <span class="lmdc-list-item__secondary-text">Tabs with support for icon and text labels</span>
             </span>
           </a>
 
 
           <!-- Text field -->
           <a href="text-field.html" mdc-list-item>
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_text_field_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_text_field_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Text field
-              <span class="mdc-list-item__secondary-text">Single and multiline text fields</span>
+              <span class="lmdc-list-item__secondary-text">Single and multiline text fields</span>
             </span>
           </a>
 
 
           <!-- Theme -->
           <a href="theme.html" mdc-list-item>
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_theme_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_theme_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Theme
-              <span class="mdc-list-item__secondary-text">Using primary and accent colors</span>
+              <span class="lmdc-list-item__secondary-text">Using primary and accent colors</span>
             </span>
           </a>
 
 
           <!-- Typography -->
           <a href="typography.html" mdc-list-item>
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_typography_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_typography_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Typography
-              <span class="mdc-list-item__secondary-text">Type hierarchy</span>
+              <span class="lmdc-list-item__secondary-text">Type hierarchy</span>
             </span>
           </a>
         </mdc-list>
         <h2>Experimental</h2>
         <mdc-list>
           <a href="experimental/tabs.html" mdc-list-item>
-            <span class="demo-catalog-list-icon mdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_tabs_24px.svg" /></span>
-            <span class="mdc-list-item__text">
+            <span class="demo-catalog-list-icon lmdc-list-item__graphic"><img class="catalog-component-icon" src="images/ic_tabs_24px.svg" /></span>
+            <span class="lmdc-list-item__text">
               Tabs
-              <span class="mdc-list-item__secondary-text">Tabs with support for dropdowns</span>
+              <span class="lmdc-list-item__secondary-text">Tabs with support for dropdowns</span>
             </span>
           </a>
         </mdc-list>

--- a/demos/list.html
+++ b/demos/list.html
@@ -11,7 +11,7 @@
   See the License for the specific language governing permissions and
   limitations under the License
 -->
-<html class="mdc-typography">
+<html class="lmdc-typography">
   <head>
     <meta charset="utf-8">
     <title>List Item - Material Components Catalog</title>
@@ -22,27 +22,27 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <style>
-      .mdc-list,
-      .mdc-list-group {
+      .lmdc-list,
+      .lmdc-list-group {
         max-width: 600px;
       }
       .grey-bg {
         background: rgba(0, 0, 0, .26);
       }
-      #icon-with-text-demo .mdc-list-item__graphic {
+      #icon-with-text-demo .lmdc-list-item__graphic {
         color: rgba(0, 0, 0, .54);
       }
-      #avatar-text-icon-demo-list .mdc-list-item__meta {
+      #avatar-text-icon-demo-list .lmdc-list-item__meta {
         text-decoration: none;
         color: #ff4081; /* Pink A200 */
       }
-      .two-line-avatar-text-icon-demo .mdc-list-item__graphic {
+      .two-line-avatar-text-icon-demo .lmdc-list-item__graphic {
         display: inline-flex;
         align-items: center;
         justify-content: center;
         color: white;
       }
-      .two-line-avatar-text-icon-demo .mdc-list-item__meta {
+      .two-line-avatar-text-icon-demo .lmdc-list-item__meta {
         color: rgba(0, 0, 0, .26);
         text-decoration: none;
       }
@@ -61,11 +61,11 @@
         padding: 24px;
       }
 
-      #demo-wrapper .mdc-list, #demo-wrapper .mdc-list-group {
+      #demo-wrapper .lmdc-list, #demo-wrapper .lmdc-list-group {
         border: 1px solid rgba(0, 0, 0, 0.1);
       }
 
-      #demo-wrapper .mdc-list-group .mdc-list {
+      #demo-wrapper .lmdc-list-group .lmdc-list {
         border: none;
       }
 
@@ -79,7 +79,7 @@
         margin-bottom: 0.8em;
       }
 
-      .hero .mdc-list {
+      .hero .lmdc-list {
         background-color: white;
         min-width: 320px;
         box-shadow:
@@ -91,29 +91,29 @@
     </style>
   </head>
   <body ng-app="demo">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">List</span>
+          <span class="lmdc-toolbar__title catalog-title">List</span>
         </section>
       </div>
     </header>
     <main ng-controller="MainCtrl">
-      <div class="mdc-toolbar-fixed-adjust"></div>
+      <div class="lmdc-toolbar-fixed-adjust"></div>
       <section class="hero" dir="{{ isRtl ? 'rtl' : ''}}">
         <mdc-list two-line="true" avatar="true" class="two-line-avatar-text-icon-demo">
           <mdc-list-item ng-repeat="folder in folder_demo">
-            <span class="mdc-list-item__graphic grey-bg" role="presentation">
+            <span class="lmdc-list-item__graphic grey-bg" role="presentation">
               <mdc-icon aria-hidden="true">folder</mdc-icon>
             </span>
-            <span class="mdc-list-item__text">
+            <span class="lmdc-list-item__text">
               {{ folder.n }}
-              <span class="mdc-list-item__secondary-text">{{ folder.d }}</span>
+              <span class="lmdc-list-item__secondary-text">{{ folder.d }}</span>
             </span>
-            <a href="#" class="mdc-list-item__meta material-icons"
+            <a href="#" class="lmdc-list-item__meta material-icons"
                aria-label="View more information" title="More info"
                onclick="event.preventDefault();">
               info
@@ -122,7 +122,7 @@
         </mdc-list>
       </section>
 
-      <section class="preamble mdc-typography--body1">
+      <section class="preamble lmdc-typography--body1">
         <aside>
           <p>
           <em>NOTE:</em> For the purposes of this demo, we've set a max-width of 600px on all
@@ -140,19 +140,19 @@
       <div id="demo-wrapper" dir="{{ isRtl ? 'rtl' : '' }}">
         <section>
           <h3>Custom Colors</h3>
-          <div class="mdc-list-group demo-list-group--custom">
-            <h3 class="mdc-list-group__subheader">Folders</h3>
+          <div class="lmdc-list-group demo-list-group--custom">
+            <h3 class="lmdc-list-group__subheader">Folders</h3>
             <mdc-list two-line="true" avatar="true"
                       class="demo-list demo-list--with-avatars demo-list--custom demo-list--icon-placeholders">
               <mdc-list-item ng-repeat="item in folder_demo">
-                  <span class="mdc-list-item__graphic grey-bg" role="presentation">
+                  <span class="lmdc-list-item__graphic grey-bg" role="presentation">
                     <mdc-icon aria-hidden="true">folder</mdc-icon>
                   </span>
-                <span class="mdc-list-item__text">
+                <span class="lmdc-list-item__text">
                     {{ item.n }}
-                    <span class="mdc-list-item__secondary-text">{{ item.d }}</span>
+                    <span class="lmdc-list-item__secondary-text">{{ item.d }}</span>
                   </span>
-                <a href="#" class="mdc-list-item__meta material-icons"
+                <a href="#" class="lmdc-list-item__meta material-icons"
                    aria-label="View more information" title="More info"
                    onclick="event.preventDefault();">
                   info
@@ -160,18 +160,18 @@
               </mdc-list-item>
             </mdc-list>
             <mdc-divider-inset></mdc-divider-inset>
-            <h3 class="mdc-list-group__subheader">Files</h3>
+            <h3 class="lmdc-list-group__subheader">Files</h3>
             <mdc-list two-line="true" avatar="true"
                       class="demo-list demo-list--with-avatars demo-list--custom demo-list--icon-placeholders">
               <mdc-list-item ng-repeat="item in folder_demo2">
-                  <span class="mdc-list-item__graphic grey-bg" role="presentation">
+                  <span class="lmdc-list-item__graphic grey-bg" role="presentation">
                     <mdc-icon aria-hidden="true">folder</mdc-icon>
                   </span>
-                <span class="mdc-list-item__text">
+                <span class="lmdc-list-item__text">
                     {{ item.n }}
-                    <span class="mdc-list-item__secondary-text">{{ item.d }}</span>
+                    <span class="lmdc-list-item__secondary-text">{{ item.d }}</span>
                   </span>
-                <a href="#" class="mdc-list-item__meta material-icons"
+                <a href="#" class="lmdc-list-item__meta material-icons"
                    aria-label="View more information" title="More info"
                    onclick="event.preventDefault();">
                   info
@@ -200,7 +200,7 @@
             <aside><p><em>Note: The grey background is styled using demo placeholder styles</em></p></aside>
             <mdc-list>
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__graphic grey-bg"></span>
+                <span class="lmdc-list-item__graphic grey-bg"></span>
                 Single-line item
               </mdc-list-item>
             </mdc-list>
@@ -209,7 +209,7 @@
             <h3>Start Detail (dense)</h3>
             <mdc-list dense="true">
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__graphic grey-bg"></span>
+                <span class="lmdc-list-item__graphic grey-bg"></span>
                 Single-line item
               </mdc-list-item>
             </mdc-list>
@@ -218,7 +218,7 @@
             <h3>Start Detail Example - Icon with Text</h3>
             <mdc-list id="icon-with-text-demo">
               <mdc-list-item ng-repeat="item in icon_demo">
-                <mdc-icon class="mdc-list-item__graphic" aria-hidden="true">
+                <mdc-icon class="lmdc-list-item__graphic" aria-hidden="true">
                   {{ item.i }}
                 </mdc-icon>
                 {{ item.n }}
@@ -229,7 +229,7 @@
             <h3>Avatar List</h3>
             <mdc-list avatar="true">
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__graphic grey-bg"></span>
+                <span class="lmdc-list-item__graphic grey-bg"></span>
                 Single-line item
               </mdc-list-item>
             </mdc-list>
@@ -238,7 +238,7 @@
             <h3>Avatar List (dense)</h3>
             <mdc-list avatar="true" dense="true">
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__graphic grey-bg"></span>
+                <span class="lmdc-list-item__graphic grey-bg"></span>
                 Single-line item
               </mdc-list-item>
             </mdc-list>
@@ -247,7 +247,7 @@
             <h3>Example - Avatar with Text</h3>
             <mdc-list avatar="true">
               <mdc-list-item ng-repeat="item in animal_demo">
-                <img class="mdc-list-item__graphic"
+                <img class="lmdc-list-item__graphic"
                      ng-src="{{ item.i }}"
                      width="56" height="56" alt="{{ item.n }}">
                 {{ item.n }}
@@ -259,7 +259,7 @@
             <mdc-list>
               <mdc-list-item ng-repeat="_ in three">
                 Single-line item
-                <span class="mdc-list-item__meta grey-bg"></span>
+                <span class="lmdc-list-item__meta grey-bg"></span>
               </mdc-list-item>
             </mdc-list>
           </section>
@@ -268,7 +268,7 @@
             <mdc-list dense="true">
               <mdc-list-item ng-repeat="_ in three">
                 Single-line item
-                <span class="mdc-list-item__meta grey-bg"></span>
+                <span class="lmdc-list-item__meta grey-bg"></span>
               </mdc-list-item>
             </mdc-list>
           </section>
@@ -276,9 +276,9 @@
             <h3>Avatar + End Detail</h3>
             <mdc-list avatar="true">
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__graphic grey-bg"></span>
+                <span class="lmdc-list-item__graphic grey-bg"></span>
                 Single-line item
-                <span class="mdc-list-item__meta grey-bg"></span>
+                <span class="lmdc-list-item__meta grey-bg"></span>
               </mdc-list-item>
             </mdc-list>
           </section>
@@ -286,9 +286,9 @@
             <h3>Avatar + End Detail (Dense)</h3>
             <mdc-list dense="true" avatar="true">
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__graphic grey-bg"></span>
+                <span class="lmdc-list-item__graphic grey-bg"></span>
                 Single-line item
-                <span class="mdc-list-item__meta grey-bg"></span>
+                <span class="lmdc-list-item__meta grey-bg"></span>
               </mdc-list-item>
             </mdc-list>
           </section>
@@ -296,11 +296,11 @@
             <h3>Example - Avatar with Text and icon</h3>
             <mdc-list id="avatar-text-icon-demo-list" avatar="true">
               <mdc-list-item ng-repeat="item in animal_demo">
-                <img class="mdc-list-item__graphic grey-bg"
+                <img class="lmdc-list-item__graphic grey-bg"
                      ng-src="{{ item.i }}"
                      width="56" height="56" alt="{{ item.n }}">
                 {{ item.n }}
-                <a class="mdc-list-item__meta material-icons" href="#"
+                <a class="lmdc-list-item__meta material-icons" href="#"
                    aria-label="{{ item.f }}" title="{{ item.f }}"
                    onclick="event.preventDefault();">
                   {{ item.f.indexOf('Add') >= 0 ? 'favorite_border' : 'favorite' }}
@@ -315,9 +315,9 @@
             <h3>Text-Only</h3>
             <mdc-list two-line="true">
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__text">
+                <span class="lmdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__secondary-text">Secondary text</span>
+                  <span class="lmdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </mdc-list-item>
             </mdc-list>
@@ -326,9 +326,9 @@
             <h3>Text-Only (Dense)</h3>
             <mdc-list two-line="true" dense="true">
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__text">
+                <span class="lmdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__secondary-text">Secondary text</span>
+                  <span class="lmdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </mdc-list-item>
             </mdc-list>
@@ -337,10 +337,10 @@
             <h3>Start Detail</h3>
             <mdc-list two-line="true">
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__graphic grey-bg"></span>
-                <span class="mdc-list-item__text">
+                <span class="lmdc-list-item__graphic grey-bg"></span>
+                <span class="lmdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__secondary-text">Secondary text</span>
+                  <span class="lmdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </mdc-list-item>
             </mdc-list>
@@ -349,10 +349,10 @@
             <h3>Start Detail (Dense)</h3>
             <mdc-list two-line="true" dense="true">
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__graphic grey-bg"></span>
-                <span class="mdc-list-item__text">
+                <span class="lmdc-list-item__graphic grey-bg"></span>
+                <span class="lmdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__secondary-text">Secondary text</span>
+                  <span class="lmdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </mdc-list-item>
             </mdc-list>
@@ -361,10 +361,10 @@
             <h3>Avatar List</h3>
             <mdc-list two-line="true" avatar="true">
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__graphic grey-bg"></span>
-                <span class="mdc-list-item__text">
+                <span class="lmdc-list-item__graphic grey-bg"></span>
+                <span class="lmdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__secondary-text">Secondary text</span>
+                  <span class="lmdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </mdc-list-item>
             </mdc-list>
@@ -373,10 +373,10 @@
             <h3>Avatar List (dense)</h3>
             <mdc-list two-line="true" avatar="true" dense="true">
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__graphic grey-bg"></span>
-                <span class="mdc-list-item__text">
+                <span class="lmdc-list-item__graphic grey-bg"></span>
+                <span class="lmdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__secondary-text">Secondary text</span>
+                  <span class="lmdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </mdc-list-item>
             </mdc-list>
@@ -385,11 +385,11 @@
             <h3>End Detail</h3>
             <mdc-list two-line="true">
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__text">
+                <span class="lmdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__secondary-text">Secondary text</span>
+                  <span class="lmdc-list-item__secondary-text">Secondary text</span>
                 </span>
-                <span class="mdc-list-item__meta grey-bg"></span>
+                <span class="lmdc-list-item__meta grey-bg"></span>
               </mdc-list-item>
             </mdc-list>
           </section>
@@ -397,11 +397,11 @@
             <h3>End Detail (Dense)</h3>
             <mdc-list two-line="true" dense="true">
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__text">
+                <span class="lmdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__secondary-text">Secondary text</span>
+                  <span class="lmdc-list-item__secondary-text">Secondary text</span>
                 </span>
-                <span class="mdc-list-item__meta grey-bg"></span>
+                <span class="lmdc-list-item__meta grey-bg"></span>
               </mdc-list-item>
             </mdc-list>
           </section>
@@ -409,14 +409,14 @@
             <h3>Example - Two-line avatar + text + icon</h3>
             <mdc-list two-line="true" avatar="true" class="two-line-avatar-text-icon-demo">
               <mdc-list-item ng-repeat="folder in folder_demo">
-                <span class="mdc-list-item__graphic grey-bg" role="presentation">
+                <span class="lmdc-list-item__graphic grey-bg" role="presentation">
                   <mdc-icon aria-hidden="true">folder</mdc-icon>
                 </span>
-                <span class="mdc-list-item__text">
+                <span class="lmdc-list-item__text">
                   {{ folder.n }}
-                  <span class="mdc-list-item__secondary-text">{{ folder.d }}</span>
+                  <span class="lmdc-list-item__secondary-text">{{ folder.d }}</span>
                 </span>
-                <a href="#" class="mdc-list-item__meta material-icons"
+                <a href="#" class="lmdc-list-item__meta material-icons"
                    aria-label="View more information" title="More info"
                    onclick="event.preventDefault();">
                   info
@@ -439,12 +439,12 @@
             <h3>Inset Dividers</h3>
             <mdc-list avatar="true">
               <mdc-list-item ng-repeat="_ in three">
-                <span class="mdc-list-item__graphic grey-bg"></span>
+                <span class="lmdc-list-item__graphic grey-bg"></span>
                 Single-line item - section 1
               </mdc-list-item>
               <mdc-divider-inset></mdc-divider-inset>
               <mdc-list-item ng-repeat="_ in two">
-                <span class="mdc-list-item__graphic grey-bg"></span>
+                <span class="lmdc-list-item__graphic grey-bg"></span>
                 Single-line item - section 2
               </mdc-list-item>
             </mdc-list>
@@ -454,13 +454,13 @@
           <h2>List Groups</h2>
           <section>
             <h3>Basic Usage</h3>
-            <div class="mdc-list-group">
-              <h3 class="mdc-list-group__subheader">List 1</h3>
+            <div class="lmdc-list-group">
+              <h3 class="lmdc-list-group__subheader">List 1</h3>
               <mdc-list>
                 <mdc-list-item ng-repeat="_ in three">Single-line item</mdc-list-item>
               </mdc-list>
               <mdc-divider></mdc-divider>
-              <h3 class="mdc-list-group__subheader">List 2</h3>
+              <h3 class="lmdc-list-group__subheader">List 2</h3>
               <mdc-list>
                 <mdc-list-item ng-repeat="_ in three">Single-line item</mdc-list-item>
               </mdc-list>
@@ -468,18 +468,18 @@
           </section>
           <section>
             <h3>Example - Two-line Lists, Avatars, end detail, inset dividers</h3>
-            <div class="mdc-list-group">
-              <h3 class="mdc-list-group__subheader">Folders</h3>
+            <div class="lmdc-list-group">
+              <h3 class="lmdc-list-group__subheader">Folders</h3>
               <mdc-list two-line="true" avatar="true" class="two-line-avatar-text-icon-demo">
                 <mdc-list-item ng-repeat="item in folder_demo">
-                  <span class="mdc-list-item__graphic grey-bg" role="presentation">
+                  <span class="lmdc-list-item__graphic grey-bg" role="presentation">
                     <mdc-icon aria-hidden="true">folder</mdc-icon>
                   </span>
-                  <span class="mdc-list-item__text">
+                  <span class="lmdc-list-item__text">
                     {{ item.n }}
-                    <span class="mdc-list-item__secondary-text">{{ item.d }}</span>
+                    <span class="lmdc-list-item__secondary-text">{{ item.d }}</span>
                   </span>
-                  <a href="#" class="mdc-list-item__meta material-icons"
+                  <a href="#" class="lmdc-list-item__meta material-icons"
                      aria-label="View more information" title="More info"
                      onclick="event.preventDefault();">
                     info
@@ -487,17 +487,17 @@
                 </mdc-list-item>
               </mdc-list>
               <mdc-divider-inset></mdc-divider-inset>
-              <h3 class="mdc-list-group__subheader">Files</h3>
+              <h3 class="lmdc-list-group__subheader">Files</h3>
               <mdc-list two-line="true" avatar="true" class="two-line-avatar-text-icon-demo">
                 <mdc-list-item ng-repeat="item in folder_demo2">
-                  <span class="mdc-list-item__graphic grey-bg" role="presentation">
+                  <span class="lmdc-list-item__graphic grey-bg" role="presentation">
                     <mdc-icon aria-hidden="true">folder</mdc-icon>
                   </span>
-                  <span class="mdc-list-item__text">
+                  <span class="lmdc-list-item__text">
                     {{ item.n }}
-                    <span class="mdc-list-item__secondary-text">{{ item.d }}</span>
+                    <span class="lmdc-list-item__secondary-text">{{ item.d }}</span>
                   </span>
-                  <a href="#" class="mdc-list-item__meta material-icons"
+                  <a href="#" class="lmdc-list-item__meta material-icons"
                      aria-label="View more information" title="More info"
                      onclick="event.preventDefault();">
                     info
@@ -512,8 +512,8 @@
           <section>
             <h3>Example - Interactive List</h3>
             <mdc-list>
-              <a href="#" class="mdc-list-item" ng-repeat="item in icon_demo">
-                <mdc-icon class="mdc-list-item__graphic" aria-hidden="true">
+              <a href="#" class="lmdc-list-item" ng-repeat="item in icon_demo">
+                <mdc-icon class="lmdc-list-item__graphic" aria-hidden="true">
                   {{ item.i }}
                 </mdc-icon>
                 {{ item.n }}

--- a/demos/menu.html
+++ b/demos/menu.html
@@ -53,7 +53,7 @@
         width: 320px;
       }
 
-      .mdc-menu-anchor {
+      .lmdc-menu-anchor {
         position: absolute;
         margin: 16px;
       }
@@ -78,19 +78,19 @@
     </style>
   </head>
   <body ng-app="demo">
-    <header class="mdc-toolbar mdc-toolbar--fixed demo-header-toolbar">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed demo-header-toolbar">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Menu</span>
+          <span class="lmdc-toolbar__title catalog-title">Menu</span>
         </section>
       </div>
     </header>
 
     <main ng-controller="MainCtrl">
-      <div class="mdc-toolbar-fixed-adjust"></div>
+      <div class="lmdc-toolbar-fixed-adjust"></div>
       <section class="hero">
         <mdc-menu id="heroDemo" tabindex="0">
           <mdc-menu-item>Back</mdc-menu-item>

--- a/demos/radio.html
+++ b/demos/radio.html
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License
 -->
-<html class="mdc-typography">
+<html class="lmdc-typography">
   <head>
     <meta charset="utf-8">
     <title>Radio Button - Material Components Demo</title>
@@ -32,18 +32,18 @@
     </style>
   </head>
   <body ng-app="demo" ng-controller="MainCtrl">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Radio</span>
+          <span class="lmdc-toolbar__title catalog-title">Radio</span>
         </section>
       </div>
     </header>
     <main>
-      <div class="mdc-toolbar-fixed-adjust"></div>
+      <div class="lmdc-toolbar-fixed-adjust"></div>
       <section class="hero">
 
         <mdc-radio ng-model="hero" ng-value="1"></mdc-radio>

--- a/demos/radio.scss
+++ b/demos/radio.scss
@@ -2,7 +2,7 @@
 @import '~@material/theme/color-palette';
 @import '~@material/radio/mixins';
 
-.mdc-radio.demo-radio--custom {
+.lmdc-radio.demo-radio--custom {
   $color: $material-color-red-500;
 
   @include mdc-radio-unchecked-stroke-color($color);

--- a/demos/ripple.html
+++ b/demos/ripple.html
@@ -37,7 +37,7 @@
         -webkit-user-select: none;
       }
 
-      .mdc-ripple-surface[data-mdc-ripple-is-unbounded] {
+      .lmdc-ripple-surface[data-mdc-ripple-is-unbounded] {
         width: 40px;
         height: 40px;
         padding: 0;
@@ -104,30 +104,30 @@
       }
     </style>
   </head>
-  <body ng-app="demo" class="mdc-typography">
+  <body ng-app="demo" class="lmdc-typography">
     <aside id="unsupported-msg">
       It appears your browser does not support custom properties, or has a broken implementation.
       Please try this in Chrome, Firefox, or Safari 10+.
     </aside>
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Ripple</span>
+          <span class="lmdc-toolbar__title catalog-title">Ripple</span>
         </section>
       </div>
     </header>
     <main ng-controller="MainCtrl">
-      <div class="mdc-toolbar-fixed-adjust"></div>
+      <div class="lmdc-toolbar-fixed-adjust"></div>
 
-      <section class="hero mdc-ripple-surface"></section>
+      <section class="hero lmdc-ripple-surface"></section>
 
       <section class="example">
         <div>
           <h2>Bounded</h2>
-          <div class="demo-surface mdc-elevation--z2" mdc-ripple>
+          <div class="demo-surface lmdc-elevation--z2" mdc-ripple>
             Interact with me!
           </div>
         </div>
@@ -135,7 +135,7 @@
       <section class="example">
         <div>
           <h2>Unbounded</h2>
-          <div class="demo-surface mdc-elevation--z2" mdc-ripple data-mdc-ripple-is-unbounded="true">
+          <div class="demo-surface lmdc-elevation--z2" mdc-ripple data-mdc-ripple-is-unbounded="true">
             <mdc-icon>favorite</mdc-icon>
           </div>
         </div>
@@ -144,11 +144,11 @@
         <div>
           <h2>Theme Styles</h2>
           <div mdc-ripple
-               class="mdc-ripple-surface--primary mdc-theme--primary demo-surface mdc-elevation--z2">
+               class="lmdc-ripple-surface--primary lmdc-theme--primary demo-surface lmdc-elevation--z2">
             Primary
           </div>
           <div mdc-ripple
-               class="mdc-ripple-surface--accent mdc-theme--secondary demo-surface mdc-elevation--z2">
+               class="lmdc-ripple-surface--accent lmdc-theme--secondary demo-surface lmdc-elevation--z2">
             Secondary
           </div>
         </div>
@@ -157,7 +157,7 @@
         <div>
           <h2>Applied to <code>&lt;button&gt;</code> element</h2>
           <button mdc-ripple type="button"
-                  class="mdc-elevation--z2 demo-surface">button</button>
+                  class="lmdc-elevation--z2 demo-surface">button</button>
         </div>
       </section>
     </main>

--- a/demos/select.html
+++ b/demos/select.html
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License
 -->
-<html class="mdc-typography">
+<html class="lmdc-typography">
   <head>
     <meta charset="utf-8">
     <title>Select Menu - Material Components Catalog</title>
@@ -32,19 +32,19 @@
     </style>
   </head>
   <body ng-app="demo">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Select</span>
+          <span class="lmdc-toolbar__title catalog-title">Select</span>
         </section>
       </div>
     </header>
 
     <main ng-controller="MainCtrl">
-      <div class="mdc-toolbar-fixed-adjust"></div>
+      <div class="lmdc-toolbar-fixed-adjust"></div>
       <section class="hero">
         <mdc-select label="Pick a food group" auto-resize="false">
           <mdc-select-item>Bread, Cereal, Rice, and Pasta</mdc-select-item>
@@ -57,7 +57,7 @@
       </section>
 
       <section class="example">
-        <h2 class="mdc-typography--title">Fully-Featured Component</h2>
+        <h2 class="lmdc-typography--title">Fully-Featured Component</h2>
         <section dir="{{ isRTL ? 'rtl': '' }}">
           <mdc-select label="Pick a food group"
                       ng-class="{'demo-select-custom-colors': altColors}"
@@ -89,7 +89,7 @@
       </section>
 
       <section class="example">
-        <h2 class="mdc-typography--title">Select box</h2>
+        <h2 class="lmdc-typography--title">Select box</h2>
         <section dir="{{ isRTL ? 'rtl': '' }}">
           <mdc-select label="Pick a food group" box="true"
                       ng-class="{'demo-select-custom-colors': altColors}"
@@ -121,7 +121,7 @@
       </section>
 
       <section class="example">
-        <h2 class="mdc-typography--title">With ng-repeat</h2>
+        <h2 class="lmdc-typography--title">With ng-repeat</h2>
         <mdc-select label="Items" ng-model="repeatSelected">
           <mdc-select-item ng-repeat="i in six" ng-value="i" ng-bind="::$index + 1"></mdc-select-item>
         </mdc-select>

--- a/demos/select.scss
+++ b/demos/select.scss
@@ -11,7 +11,7 @@
   @include mdc-select-focused-label-color(green);
 }
 
-.demo-select-custom-colors.mdc-select--box {
+.demo-select-custom-colors.lmdc-select--box {
   @include mdc-select-container-fill-color(rgba(blue, .1));
 }
 // stylelint-enable selector-class-pattern

--- a/demos/snackbar.html
+++ b/demos/snackbar.html
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License
 -->
-<html class="mdc-typography">
+<html class="lmdc-typography">
   <head>
     <meta charset="utf-8">
     <title>Snackbar - Material Components Catalog</title>
@@ -26,11 +26,11 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <style>
       /* Override style for hero example. */
-      .hero .mdc-snackbar {
+      .hero .lmdc-snackbar {
         position: relative;
         left: auto;
       }
-      .hero .mdc-snackbar--active {
+      .hero .lmdc-snackbar--active {
         transform: none;
       }
 
@@ -45,27 +45,27 @@
   </head>
   <body ng-app="demo" class="loading" ng-controller="MainCtrl"
         dir="{{ isRTL ? 'rtl' : '' }}">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Snackbar</span>
+          <span class="lmdc-toolbar__title catalog-title">Snackbar</span>
         </section>
       </div>
     </header>
 
     <main>
-      <div class="mdc-toolbar-fixed-adjust"></div>
+      <div class="lmdc-toolbar-fixed-adjust"></div>
       <section class="hero">
-        <div class="mdc-snackbar mdc-snackbar--active"
+        <div class="lmdc-snackbar lmdc-snackbar--active"
              aria-live="assertive"
              aria-atomic="true"
              aria-hidden="true">
-          <div class="mdc-snackbar__text">Message sent</div>
-          <div class="mdc-snackbar__action-wrapper">
-            <button mdc-button type="button" class="mdc-snackbar__action-button">Undo</button>
+          <div class="lmdc-snackbar__text">Message sent</div>
+          <div class="lmdc-snackbar__action-wrapper">
+            <button mdc-button type="button" class="lmdc-snackbar__action-button">Undo</button>
           </div>
         </div>
       </section>
@@ -73,7 +73,7 @@
 
       <section class="example">
         <div>
-          <h2 class="mdc-typography--title">Basic Example</h2>
+          <h2 class="lmdc-typography--title">Basic Example</h2>
 
           <mdc-form-field>
             <mdc-checkbox ng-model="multiline"></mdc-checkbox>

--- a/demos/switch.html
+++ b/demos/switch.html
@@ -47,19 +47,19 @@
       }
     </style>
   </head>
-  <body ng-app="demo" class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed demo-header-toolbar">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+  <body ng-app="demo" class="lmdc-typography">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed demo-header-toolbar">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Switch</span>
+          <span class="lmdc-toolbar__title catalog-title">Switch</span>
         </section>
       </div>
     </header>
     <main ng-controller="MainCtrl">
-      <div class="mdc-toolbar-fixed-adjust"></div>
+      <div class="lmdc-toolbar-fixed-adjust"></div>
       <section class="hero">
         <div>
           <mdc-switch ng-disabled="isDisabled" ng-model="isToggled"></mdc-switch>

--- a/demos/tabs.html
+++ b/demos/tabs.html
@@ -66,7 +66,7 @@ limitations under the License
         padding: 0 40px 40px;
       }
 
-      .mdc-tab-bar-scroller {
+      .lmdc-tab-bar-scroller {
         margin-bottom: 16px;
       }
 
@@ -125,18 +125,18 @@ limitations under the License
     </style>
   </head>
   <body ng-app="demo">
-    <header class="mdc-toolbar mdc-toolbar--fixed demo-header-toolbar">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed demo-header-toolbar">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Tabs</span>
+          <span class="lmdc-toolbar__title catalog-title">Tabs</span>
         </section>
       </div>
     </header>
 
-    <main ng-controller="MainCtrl" dir="{{ isRTL ? 'rtl' : '' }}" class="mdc-toolbar-fixed-adjust">
+    <main ng-controller="MainCtrl" dir="{{ isRTL ? 'rtl' : '' }}" class="lmdc-toolbar-fixed-adjust">
       <section class="hero">
         <mdc-tab-bar>
           <mdc-tab>Item One</mdc-tab>
@@ -151,7 +151,7 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Basic Tab Bar</legend>
+          <legend class="lmdc-typography--title">Basic Tab Bar</legend>
           <mdc-tab-bar ng-model="cycleSelect">
             <mdc-tab ng-value="0">Item One</mdc-tab>
             <mdc-tab ng-value="1">Item Two</mdc-tab>
@@ -164,7 +164,7 @@ limitations under the License
       </section>
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Basic Tab Bar w/ Custom Label Color</legend>
+          <legend class="lmdc-typography--title">Basic Tab Bar w/ Custom Label Color</legend>
           <mdc-tab-bar ng-model="clicked" class="custom-label-color-tab">
             <mdc-tab ng-value="undefined">One (undefined)</mdc-tab>
             <mdc-tab ng-value="'Two'">Two ("Two")</mdc-tab>
@@ -178,7 +178,7 @@ limitations under the License
 
       <section>
         <div class="demo-tabs__scroller">
-          <h2 class="mdc-typography--title demo-title">Tab Bar with Scroller</h2>
+          <h2 class="lmdc-typography--title demo-title">Tab Bar with Scroller</h2>
           <mdc-tab-bar-scroller>
             <mdc-tab-bar ng-model="scroll.selected" ng-if="demoToggled">
               <mdc-tab ng-repeat="num in numbers" value="{{ $index + 1 }}">Item {{ num }}</mdc-tab>
@@ -192,16 +192,16 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Icon Tab Labels</legend>
+          <legend class="lmdc-typography--title">Icon Tab Labels</legend>
           <mdc-tab-bar variant="icon" ng-if="demoToggled">
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-label="Recents">phone</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-label="Recents">phone</mdc-icon>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-label="Favorites">favorite</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-label="Favorites">favorite</mdc-icon>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-label="nearby">person_pin</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-label="nearby">person_pin</mdc-icon>
             </mdc-tab>
           </mdc-tab-bar>
         </fieldset>
@@ -209,16 +209,16 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Icon Tab Labels w/ Custom Icon Color</legend>
+          <legend class="lmdc-typography--title">Icon Tab Labels w/ Custom Icon Color</legend>
           <mdc-tab-bar variant="icon" class="custom-icon-color-tab" ng-if="demoToggled">
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-label="Recents">phone</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-label="Recents">phone</mdc-icon>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-label="Favorites">favorite</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-label="Favorites">favorite</mdc-icon>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-label="nearby">person_pin</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-label="nearby">person_pin</mdc-icon>
             </mdc-tab>
           </mdc-tab-bar>
         </fieldset>
@@ -226,18 +226,18 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Icon &amp; Text Labels</legend>
+          <legend class="lmdc-typography--title">Icon &amp; Text Labels</legend>
           <mdc-tab-bar variant="icons-text">
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-hidden="true">phone</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-hidden="true">phone</mdc-icon>
               <mdc-tab-text>Recents</mdc-tab-text>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-hidden="true">favorite</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-hidden="true">favorite</mdc-icon>
               <mdc-tab-text>Favorites</mdc-tab-text>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-hidden="true">person_pin</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-hidden="true">person_pin</mdc-icon>
               <mdc-tab-text>Nearby</mdc-tab-text>
             </mdc-tab>
           </mdc-tab-bar>
@@ -246,18 +246,18 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Icon &amp; Text Labels w/ Custom Colors</legend>
+          <legend class="lmdc-typography--title">Icon &amp; Text Labels w/ Custom Colors</legend>
           <mdc-tab-bar variant="icons-text" class="custom-ink-color-tab">
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-hidden="true">phone</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-hidden="true">phone</mdc-icon>
               <mdc-tab-text>Recents</mdc-tab-text>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-hidden="true">favorite</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-hidden="true">favorite</mdc-icon>
               <mdc-tab-text>Favorites</mdc-tab-text>
             </mdc-tab>
             <mdc-tab>
-              <mdc-icon class="mdc-tab__icon" aria-hidden="true">person_pin</mdc-icon>
+              <mdc-icon class="lmdc-tab__icon" aria-hidden="true">person_pin</mdc-icon>
               <mdc-tab-text>Nearby</mdc-tab-text>
             </mdc-tab>
           </mdc-tab-bar>
@@ -266,7 +266,7 @@ limitations under the License
 
       <section>
         <div class="demo-tabs__scroller">
-          <h2 class="mdc-typography--title demo-title">Custom Indicator Color</h2>
+          <h2 class="lmdc-typography--title demo-title">Custom Indicator Color</h2>
           <mdc-tab-bar-scroller>
             <mdc-tab-bar class="custom-indicator-tab-bar" ng-model="mutable.sel" ng-if="demoToggled">
               <mdc-tab ng-repeat="item in mutable.list"
@@ -284,13 +284,13 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Within mdc-toolbar</legend>
-          <div class="mdc-toolbar">
-            <div class="mdc-toolbar__row">
-              <div class="mdc-toolbar__section mdc-toolbar__section--shrink-to-fit mdc-toolbar__section--align-start">
-                <h2 class="mdc-toolbar__title">Title</h2>
+          <legend class="lmdc-typography--title">Within mdc-toolbar</legend>
+          <div class="lmdc-toolbar">
+            <div class="lmdc-toolbar__row">
+              <div class="lmdc-toolbar__section lmdc-toolbar__section--shrink-to-fit lmdc-toolbar__section--align-start">
+                <h2 class="lmdc-toolbar__title">Title</h2>
               </div>
-              <div class="mdc-toolbar__section mdc-toolbar__section--align-end">
+              <div class="lmdc-toolbar__section lmdc-toolbar__section--align-end">
                 <div>
                   <mdc-tab-bar class="custom-tab-bar-in-toolbar">
                     <mdc-tab>Item One</mdc-tab>
@@ -306,7 +306,7 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Within MDCToolbar - fixed to bottom of toolbar</legend>
+          <legend class="lmdc-typography--title">Within MDCToolbar - fixed to bottom of toolbar</legend>
           <div class="demo-note">
             <em>
               Note: We want to avoid too many modifier classes for layouts like this. Therefore, we recommend overriding the style of
@@ -329,12 +329,12 @@ limitations under the License
             </code>
           </pre>
           </div>
-          <div class="mdc-toolbar">
-            <div class="mdc-toolbar__row">
-              <div class="mdc-toolbar__section mdc-toolbar__section--shrink-to-fit mdc-toolbar__section--align-start">
-                <h1 class="mdc-toolbar__title">Title</h1>
+          <div class="lmdc-toolbar">
+            <div class="lmdc-toolbar__row">
+              <div class="lmdc-toolbar__section lmdc-toolbar__section--shrink-to-fit lmdc-toolbar__section--align-start">
+                <h1 class="lmdc-toolbar__title">Title</h1>
               </div>
-              <div class="mdc-toolbar__section my-modified-toolbar-section">
+              <div class="lmdc-toolbar__section my-modified-toolbar-section">
                 <mdc-tab-bar class="custom-tab-bar-in-toolbar">
                   <mdc-tab>Item One</mdc-tab>
                   <mdc-tab>Item Two</mdc-tab>
@@ -348,16 +348,16 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Within mdc-toolbar + custom color indicator</legend>
+          <legend class="lmdc-typography--title">Within mdc-toolbar + custom color indicator</legend>
           <div class="demo-note">
             <em>Note: Changing the toolbar's background color here so that the primary indicator can be visible</em>
           </div>
-          <div class="mdc-toolbar mdc-theme--accent-bg">
-            <div class="mdc-toolbar__row">
-              <div class="mdc-toolbar__section mdc-toolbar__section--shrink-to-fit mdc-toolbar__section--align-start">
-                <h1 class="mdc-toolbar__title">Title</h1>
+          <div class="lmdc-toolbar lmdc-theme--accent-bg">
+            <div class="lmdc-toolbar__row">
+              <div class="lmdc-toolbar__section lmdc-toolbar__section--shrink-to-fit lmdc-toolbar__section--align-start">
+                <h1 class="lmdc-toolbar__title">Title</h1>
               </div>
-              <div class="mdc-toolbar__section mdc-toolbar__section--align-end">
+              <div class="lmdc-toolbar__section lmdc-toolbar__section--align-end">
                 <div>
                   <mdc-tab-bar class="custom-indicator-tab-bar-in-toolbar">
                     <mdc-tab>Item One</mdc-tab>
@@ -373,10 +373,10 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Within Toolbar, Dynamic Content Control</legend>
-          <div class="mdc-toolbar" id="dynamic-demo-toolbar">
-            <div class="mdc-toolbar__row">
-              <div class="mdc-toolbar__section mdc-toolbar__section--align-start">
+          <legend class="lmdc-typography--title">Within Toolbar, Dynamic Content Control</legend>
+          <div class="lmdc-toolbar" id="dynamic-demo-toolbar">
+            <div class="lmdc-toolbar__row">
+              <div class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
                 <mdc-tab-bar ng-model="selectedTab" class="custom-indicator-tab-bar-in-toolbar">
                   <mdc-tab ng-value="0">Item One</mdc-tab>
                   <mdc-tab ng-value="1">Item Two</mdc-tab>

--- a/demos/tabs.scss
+++ b/demos/tabs.scss
@@ -4,40 +4,40 @@
 
 
 .custom-label-color-tab {
-  .mdc-tab:not(.mdc-tab--active) {
+  .lmdc-tab:not(.lmdc-tab--active) {
     @include mdc-tab-label-ink-color($material-color-deep-purple-200);
   }
 }
 
 .custom-label-color-tab {
-  .mdc-tab--active,
-  .mdc-tab:hover {
+  .lmdc-tab--active,
+  .lmdc-tab:hover {
     @include mdc-tab-label-ink-color($material-color-indigo-500);
   }
 }
 
 .custom-icon-color-tab {
-  .mdc-tab:not(.mdc-tab--active) {
+  .lmdc-tab:not(.lmdc-tab--active) {
     @include mdc-tab-icon-ink-color($material-color-deep-purple-200);
   }
 }
 
 .custom-icon-color-tab {
-  .mdc-tab--active,
-  .mdc-tab:hover {
+  .lmdc-tab--active,
+  .lmdc-tab:hover {
     @include mdc-tab-icon-ink-color($material-color-indigo-500);
   }
 }
 
 .custom-ink-color-tab {
-  .mdc-tab:not(.mdc-tab--active) {
+  .lmdc-tab:not(.lmdc-tab--active) {
     @include mdc-tab-ink-color($material-color-deep-purple-200);
   }
 }
 
 .custom-ink-color-tab {
-  .mdc-tab--active,
-  .mdc-tab:hover {
+  .lmdc-tab--active,
+  .lmdc-tab:hover {
     @include mdc-tab-ink-color($material-color-indigo-500);
   }
 }
@@ -48,12 +48,12 @@
 
 .custom-indicator-tab-bar-in-toolbar,
 .custom-tab-bar-in-toolbar {
-  .mdc-tab:not(.mdc-tab--active) {
+  .lmdc-tab:not(.lmdc-tab--active) {
     @include mdc-tab-ink-color(rgba(mdc-theme-prop-value(text-primary-on-primary), 0.54));
   }
 
-  .mdc-tab--active,
-  .mdc-tab:hover {
+  .lmdc-tab--active,
+  .lmdc-tab:hover {
     @include mdc-tab-ink-color(text-primary-on-primary);
   }
 }

--- a/demos/text-field.html
+++ b/demos/text-field.html
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License
 -->
-<html class="mdc-typography">
+<html class="lmdc-typography">
   <head>
     <meta charset="utf-8">
     <title>Text Field - Material Components Catalog</title>
@@ -40,18 +40,18 @@
     </style>
   </head>
   <body ng-app="demo" ng-controller="MainCtrl">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Text Field</span>
+          <span class="lmdc-toolbar__title catalog-title">Text Field</span>
         </section>
       </div>
     </header>
     <main>
-      <div class="mdc-toolbar-fixed-adjust"></div>
+      <div class="lmdc-toolbar-fixed-adjust"></div>
       <section class="hero">
         <mdc-text-field label="Text field">
           <input type="text">
@@ -107,7 +107,7 @@
                  aria-controls="pw-validation-msg"
                  autocomplete="current-password">
         </mdc-text-field>
-        <p class="mdc-text-field-helptext mdc-text-field-helptext--persistent mdc-text-field-helptext--validation-msg"
+        <p class="lmdc-text-field-helptext lmdc-text-field-helptext--persistent lmdc-text-field-helptext--validation-msg"
            id="pw-validation-msg">
           Must be at least 8 characters long
         </p>

--- a/demos/text-field.scss
+++ b/demos/text-field.scss
@@ -1,7 +1,7 @@
 @import "~@material/textfield/mixins";
 
 // stylelint-disable selector-class-pattern
-.demo-text-field-custom-colors:not(.mdc-text-field--invalid) {
+.demo-text-field-custom-colors:not(.lmdc-text-field--invalid) {
   $idle-border: rgba(blue, .38);
   $hover-border: rgba(blue, .6);
   $focused-border: rgba(blue, 1);
@@ -18,13 +18,13 @@
   @include mdc-text-field-textarea-stroke-color($idle-border);
   @include mdc-text-field-icon-color($hover-border);
 
-  &.mdc-text-field--focused {
+  &.lmdc-text-field--focused {
     @include mdc-text-field-label-color(rgba(blue, .87));
     @include mdc-text-field-icon-color($focused-border);
   }
 }
 
-.demo-textarea:not(.mdc-text-field--invalid) {
+.demo-textarea:not(.lmdc-text-field--invalid) {
   $idle-border: rgba(blue, .38);
   $hover-border: rgba(blue, .6);
   $focused-border: rgba(blue, 1);
@@ -33,45 +33,45 @@
   @include mdc-text-field-label-color(rgba(blue, .5));
   @include mdc-text-field-textarea-stroke-color($idle-border);
 
-  &.mdc-text-field--focused {
+  &.lmdc-text-field--focused {
     @include mdc-text-field-label-color(rgba(blue, .87));
     @include mdc-text-field-textarea-stroke-color($focused-border);
   }
 }
 
-.demo-textarea.mdc-text-field--invalid {
+.demo-textarea.lmdc-text-field--invalid {
   @include mdc-text-field-ink-color(orange);
   @include mdc-text-field-label-color(rgba(orange, .5));
   @include mdc-text-field-textarea-stroke-color(orange);
 
-  &.mdc-text-field--focused {
+  &.lmdc-text-field--focused {
     @include mdc-text-field-label-color(rgba(orange, .87));
     @include mdc-text-field-textarea-stroke-color(orange);
   }
 }
 
-.demo-fullwidth-input:not(.mdc-text-field--invalid) {
+.demo-fullwidth-input:not(.lmdc-text-field--invalid) {
   @include mdc-text-field-ink-color(black);
   @include mdc-text-field-label-color(rgba(blue, .5));
   @include mdc-text-field-line-ripple-color(blue);
 
-  &.mdc-text-field--focused {
+  &.lmdc-text-field--focused {
     @include mdc-text-field-label-color(rgba(blue, .87));
   }
 }
 
-.demo-fullwidth-input.mdc-text-field--invalid {
+.demo-fullwidth-input.lmdc-text-field--invalid {
   @include mdc-text-field-ink-color(orange);
   @include mdc-text-field-label-color(rgba(orange, .5));
   @include mdc-text-field-line-ripple-color(orange);
 
-  &.mdc-text-field--focused {
+  &.lmdc-text-field--focused {
     @include mdc-text-field-label-color(rgba(orange, .87));
     @include mdc-text-field-fullwidth-bottom-line-color(orange);
   }
 }
 
-.demo-text-field-custom-error-colors.mdc-text-field--invalid {
+.demo-text-field-custom-error-colors.lmdc-text-field--invalid {
   $idle-border: rgba(orange, .38);
   $hover-border: rgba(orange, .6);
   $focused-border: rgba(orange, 1);

--- a/demos/theme.html
+++ b/demos/theme.html
@@ -92,95 +92,95 @@
     </style>
   </head>
   <body ng-app="demo" ng-controller="MainCtrl">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Theme</span>
+          <span class="lmdc-toolbar__title catalog-title">Theme</span>
         </section>
       </div>
     </header>
     <main>
-      <div class="mdc-toolbar-fixed-adjust"></div>
+      <div class="lmdc-toolbar-fixed-adjust"></div>
       <section class="hero">
-        <button class="mdc-button mdc-button--raised mdc-theme--primary-bg mdc-theme--text-primary-on-primary">Primary</button>
-        <button class="mdc-button mdc-button--raised button mdc-theme--accent-bg mdc-theme--text-primary-on-accent">Accent</button>
+        <button class="lmdc-button lmdc-button--raised lmdc-theme--primary-bg lmdc-theme--text-primary-on-primary">Primary</button>
+        <button class="lmdc-button lmdc-button--raised button lmdc-theme--accent-bg lmdc-theme--text-primary-on-accent">Accent</button>
       </section>
 
-      <h2 class="mdc-typography--display1">Theme colors</h2>
+      <h2 class="lmdc-typography--display1">Theme colors</h2>
 
       <section class="example">
-        <h3 class="mdc-typography--title">Theme colors as text</h3>
+        <h3 class="lmdc-typography--title">Theme colors as text</h3>
         <div class="demo-theme__color">
           <div class="demo-theme__color__label">Primary</div>
-          <div class="demo-theme__color__block mdc-theme--primary mdc-typography mdc-typography--body2">Lorem ipsum</div>
+          <div class="demo-theme__color__block lmdc-theme--primary lmdc-typography lmdc-typography--body2">Lorem ipsum</div>
         </div>
         <div class="demo-theme__color">
           <div class="demo-theme__color__label">Accent</div>
-          <div class="demo-theme__color__block mdc-theme--accent mdc-typography mdc-typography--body2">Lorem ipsum</div>
+          <div class="demo-theme__color__block lmdc-theme--accent lmdc-typography lmdc-typography--body2">Lorem ipsum</div>
         </div>
       </section>
 
       <section class="example">
-        <h3 class="mdc-typography--title">Theme colors as background</h3>
+        <h3 class="lmdc-typography--title">Theme colors as background</h3>
         <div class="demo-theme__color">
           <div class="demo-theme__color__label">Primary</div>
-          <div class="demo-theme__color__block mdc-theme--primary-bg"></div>
+          <div class="demo-theme__color__block lmdc-theme--primary-bg"></div>
         </div>
         <div class="demo-theme__color">
           <div class="demo-theme__color__label">Accent</div>
-          <div class="demo-theme__color__block mdc-theme--accent-bg"></div>
+          <div class="demo-theme__color__block lmdc-theme--accent-bg"></div>
         </div>
         <div class="demo-theme__color">
           <div class="demo-theme__color__label">Background</div>
-          <div class="demo-theme__color__block mdc-theme--background"></div>
+          <div class="demo-theme__color__block lmdc-theme--background"></div>
         </div>
       </section>
 
-      <h2 class="mdc-typography--display1">Text colors for contrast</h2>
+      <h2 class="lmdc-typography--display1">Text colors for contrast</h2>
 
       <section class="example">
-        <h3 class="mdc-typography--title">Text on background</h3>
-        <div class="demo-theme__text-styles mdc-theme--background mdc-typography mdc-typography--body2">
-          <span class="mdc-theme--text-primary-on-background">Primary</span>
-          <span class="mdc-theme--text-secondary-on-background">Secondary</span>
-          <span class="mdc-theme--text-hint-on-background">Hint</span>
-          <span class="mdc-theme--text-disabled-on-background">Disabled</span>
-          <span class="mdc-theme--text-icon-on-background material-icons">favorite</span>
+        <h3 class="lmdc-typography--title">Text on background</h3>
+        <div class="demo-theme__text-styles lmdc-theme--background lmdc-typography lmdc-typography--body2">
+          <span class="lmdc-theme--text-primary-on-background">Primary</span>
+          <span class="lmdc-theme--text-secondary-on-background">Secondary</span>
+          <span class="lmdc-theme--text-hint-on-background">Hint</span>
+          <span class="lmdc-theme--text-disabled-on-background">Disabled</span>
+          <span class="lmdc-theme--text-icon-on-background material-icons">favorite</span>
         </div>
-        <h3 class="mdc-typography--title">Text on primary</h3>
-        <div class="demo-theme__text-styles mdc-theme--primary-bg mdc-typography mdc-typography--body2">
-          <span class="mdc-theme--text-primary-on-primary">Primary</span>
-          <span class="mdc-theme--text-secondary-on-primary">Secondary</span>
-          <span class="mdc-theme--text-hint-on-primary">Hint</span>
-          <span class="mdc-theme--text-disabled-on-primary">Disabled</span>
-          <span class="mdc-theme--text-icon-on-primary material-icons">favorite</span>
+        <h3 class="lmdc-typography--title">Text on primary</h3>
+        <div class="demo-theme__text-styles lmdc-theme--primary-bg lmdc-typography lmdc-typography--body2">
+          <span class="lmdc-theme--text-primary-on-primary">Primary</span>
+          <span class="lmdc-theme--text-secondary-on-primary">Secondary</span>
+          <span class="lmdc-theme--text-hint-on-primary">Hint</span>
+          <span class="lmdc-theme--text-disabled-on-primary">Disabled</span>
+          <span class="lmdc-theme--text-icon-on-primary material-icons">favorite</span>
         </div>
-        <h3 class="mdc-typography--title">Text on accent</h3>
-        <div class="demo-theme__text-styles mdc-theme--accent-bg mdc-typography mdc-typography--body2">
-          <span class="mdc-theme--text-primary-on-accent">Primary</span>
-          <span class="mdc-theme--text-secondary-on-accent">Secondary</span>
-          <span class="mdc-theme--text-hint-on-accent">Hint</span>
-          <span class="mdc-theme--text-disabled-on-accent">Disabled</span>
-          <span class="mdc-theme--text-icon-on-accent material-icons">favorite</span>
+        <h3 class="lmdc-typography--title">Text on accent</h3>
+        <div class="demo-theme__text-styles lmdc-theme--accent-bg lmdc-typography lmdc-typography--body2">
+          <span class="lmdc-theme--text-primary-on-accent">Primary</span>
+          <span class="lmdc-theme--text-secondary-on-accent">Secondary</span>
+          <span class="lmdc-theme--text-hint-on-accent">Hint</span>
+          <span class="lmdc-theme--text-disabled-on-accent">Disabled</span>
+          <span class="lmdc-theme--text-icon-on-accent material-icons">favorite</span>
         </div>
-        <h3 class="mdc-typography--title">Text on user-defined light background</h3>
-        <div class="demo-theme__text-styles demo-theme--custom-light-bg mdc-typography mdc-typography--body2">
-          <span class="mdc-theme--text-primary-on-light">Primary</span>
-          <span class="mdc-theme--text-secondary-on-light">Secondary</span>
-          <span class="mdc-theme--text-hint-on-light">Hint</span>
-          <span class="mdc-theme--text-disabled-on-light">Disabled</span>
-          <span class="mdc-theme--text-icon-on-light material-icons">favorite</span>
+        <h3 class="lmdc-typography--title">Text on user-defined light background</h3>
+        <div class="demo-theme__text-styles demo-theme--custom-light-bg lmdc-typography lmdc-typography--body2">
+          <span class="lmdc-theme--text-primary-on-light">Primary</span>
+          <span class="lmdc-theme--text-secondary-on-light">Secondary</span>
+          <span class="lmdc-theme--text-hint-on-light">Hint</span>
+          <span class="lmdc-theme--text-disabled-on-light">Disabled</span>
+          <span class="lmdc-theme--text-icon-on-light material-icons">favorite</span>
         </div>
-        <h3 class="mdc-typography--title">Text on user-defined dark background</h3>
-        <div class="demo-theme__text-styles demo-theme--custom-dark-bg mdc-typography mdc-typography--body2">
-          <span class="mdc-theme--text-primary-on-dark">Primary</span>
-          <span class="mdc-theme--text-secondary-on-dark">Secondary</span>
-          <span class="mdc-theme--text-hint-on-dark">Hint</span>
-          <span class="mdc-theme--text-disabled-on-dark">Disabled</span>
-          <span class="mdc-theme--text-icon-on-dark material-icons">favorite</span>
+        <h3 class="lmdc-typography--title">Text on user-defined dark background</h3>
+        <div class="demo-theme__text-styles demo-theme--custom-dark-bg lmdc-typography lmdc-typography--body2">
+          <span class="lmdc-theme--text-primary-on-dark">Primary</span>
+          <span class="lmdc-theme--text-secondary-on-dark">Secondary</span>
+          <span class="lmdc-theme--text-hint-on-dark">Hint</span>
+          <span class="lmdc-theme--text-disabled-on-dark">Disabled</span>
+          <span class="lmdc-theme--text-icon-on-dark material-icons">favorite</span>
         </div>
       </section>
     </main>

--- a/demos/typography.html
+++ b/demos/typography.html
@@ -33,58 +33,58 @@
     </style>
   </head>
   <body ng-app="demo" ng-controller="MainCtrl">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+    <header class="lmdc-toolbar lmdc-toolbar--fixed">
+      <div class="lmdc-toolbar__row">
+        <section class="lmdc-toolbar__section lmdc-toolbar__section--align-start">
           <span class="catalog-back">
-            <a href="./" class="mdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
+            <a href="./" class="lmdc-toolbar__menu-icon"><mdc-icon>arrow_back</mdc-icon></a>
           </span>
-          <span class="mdc-toolbar__title catalog-title">Typography</span>
+          <span class="lmdc-toolbar__title catalog-title">Typography</span>
         </section>
       </div>
     </header>
     <main>
-      <div class="mdc-toolbar-fixed-adjust"></div>
+      <div class="lmdc-toolbar-fixed-adjust"></div>
       <section class="hero">
-        <h2 class="mdc-typography--display4">Tt</h2>
+        <h2 class="lmdc-typography--display4">Tt</h2>
       </section>
 
-      <section class="demo-typography--section mdc-typography">
-        <h2 class="mdc-typography--display1">Styles</h2>
-        <h1 class="mdc-typography--display4">Display 4</h1>
-        <h1 class="mdc-typography--display3">Display 3</h1>
-        <h1 class="mdc-typography--display2">Display 2</h1>
-        <h1 class="mdc-typography--display1">Display 1</h1>
-        <h1 class="mdc-typography--headline">Headline</h1>
-        <h2 class="mdc-typography--title">
-          Title <span class="mdc-typography--caption">Caption.</span>
+      <section class="demo-typography--section lmdc-typography">
+        <h2 class="lmdc-typography--display1">Styles</h2>
+        <h1 class="lmdc-typography--display4">Display 4</h1>
+        <h1 class="lmdc-typography--display3">Display 3</h1>
+        <h1 class="lmdc-typography--display2">Display 2</h1>
+        <h1 class="lmdc-typography--display1">Display 1</h1>
+        <h1 class="lmdc-typography--headline">Headline</h1>
+        <h2 class="lmdc-typography--title">
+          Title <span class="lmdc-typography--caption">Caption.</span>
         </h2>
-        <h3 class="mdc-typography--subheading2">Subheading 2</h3>
-        <h4 class="mdc-typography--subheading1">Subheading 1</h4>
-        <p class="mdc-typography--body1">Body 1 paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        <h3 class="lmdc-typography--subheading2">Subheading 2</h3>
+        <h4 class="lmdc-typography--subheading1">Subheading 1</h4>
+        <p class="lmdc-typography--body1">Body 1 paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
           do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
           exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit
           in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
-        <aside class="mdc-typography--body2">Body 2 text, calling something out.</aside>
+        <aside class="lmdc-typography--body2">Body 2 text, calling something out.</aside>
       </section>
 
-      <section class="demo-typography--section mdc-typography">
-        <h2 class="mdc-typography--display1">Styles with margin adjustments</h2>
-        <h1 class="mdc-typography--display4 mdc-typography--adjust-margin">Display 4</h1>
-        <h1 class="mdc-typography--display3 mdc-typography--adjust-margin">Display 3</h1>
-        <h1 class="mdc-typography--display2 mdc-typography--adjust-margin">Display 2</h1>
-        <h1 class="mdc-typography--display1 mdc-typography--adjust-margin">Display 1</h1>
-        <h1 class="mdc-typography--headline mdc-typography--adjust-margin">Headline</h1>
-        <h2 class="mdc-typography--title mdc-typography--adjust-margin">
-          Title <span class="mdc-typography--caption mdc-typography--adjust-margin">Caption.</span>
+      <section class="demo-typography--section lmdc-typography">
+        <h2 class="lmdc-typography--display1">Styles with margin adjustments</h2>
+        <h1 class="lmdc-typography--display4 lmdc-typography--adjust-margin">Display 4</h1>
+        <h1 class="lmdc-typography--display3 lmdc-typography--adjust-margin">Display 3</h1>
+        <h1 class="lmdc-typography--display2 lmdc-typography--adjust-margin">Display 2</h1>
+        <h1 class="lmdc-typography--display1 lmdc-typography--adjust-margin">Display 1</h1>
+        <h1 class="lmdc-typography--headline lmdc-typography--adjust-margin">Headline</h1>
+        <h2 class="lmdc-typography--title lmdc-typography--adjust-margin">
+          Title <span class="lmdc-typography--caption lmdc-typography--adjust-margin">Caption.</span>
         </h2>
-        <h3 class="mdc-typography--subheading2 mdc-typography--adjust-margin">Subheading 2</h3>
-        <h4 class="mdc-typography--subheading1 mdc-typography--adjust-margin">Subheading 1</h4>
-        <p class="mdc-typography--body1 mdc-typography--adjust-margin">Body 1 paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        <h3 class="lmdc-typography--subheading2 lmdc-typography--adjust-margin">Subheading 2</h3>
+        <h4 class="lmdc-typography--subheading1 lmdc-typography--adjust-margin">Subheading 1</h4>
+        <p class="lmdc-typography--body1 lmdc-typography--adjust-margin">Body 1 paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
           do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
           exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit
           in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
-        <aside class="mdc-typography--body2 mdc-typography--adjust-margin">Body 2 text, calling something out.</aside>
+        <aside class="lmdc-typography--body2 lmdc-typography--adjust-margin">Body 2 text, calling something out.</aside>
       </section>
     </main>
     <script src="angular/angular.js"></script>

--- a/scripts/transform-mdc-to-lmdc.js
+++ b/scripts/transform-mdc-to-lmdc.js
@@ -1,0 +1,20 @@
+const postcss = require('postcss');
+
+
+/**
+ * @returns {function(...[*]=)}
+ */
+function transformMdcToLmdc() {
+  return (root) => {
+    root.walkRules((rule) => {
+      if (!rule.selectors) {
+        return rule;
+      }
+
+      rule.selectors = rule.selectors.map((selector) => selector.replace(/\.mdc-/g, '.lmdc-'));
+    });
+  };
+}
+
+const plugin = postcss.plugin('transform-mdc-to-lmdc', transformMdcToLmdc);
+module.exports = plugin;

--- a/src/mdc-button/directive.js
+++ b/src/mdc-button/directive.js
@@ -1,8 +1,11 @@
 import {BaseComponent} from '../util/base-component';
 import {arrayUnion} from '../util/array-union';
+import {replaceMdcClassname} from '../util/replace-mdc-classname';
+import {BASE_CLASSNAME as DIALOG_BASE_CLASSNAME} from '../mdc-dialog/component/dialog';
 
 import {MDCRippleMixin} from '../mdc-ripple/mixin';
 
+const BASE_CLASSNAME = replaceMdcClassname('mdc-button');
 
 /**
  * @ngdoc directive
@@ -42,7 +45,7 @@ export class MDCButtonController extends MDCRippleMixin(BaseComponent) {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-button');
+    this.$element.addClass(BASE_CLASSNAME);
   }
 
   $onChanges(changes) {
@@ -50,13 +53,16 @@ export class MDCButtonController extends MDCRippleMixin(BaseComponent) {
 
     ['dense', 'raised', 'compact', 'unelevated', 'stroked'].forEach((attr) => {
       if (changes[attr]) {
-        this.$element.toggleClass('mdc-button--' + attr, Boolean(this[attr]));
+        this.$element.toggleClass(`${BASE_CLASSNAME}--${attr}`, Boolean(this[attr]));
       }
     });
     if (changes.dialog) {
-      this.$element.toggleClass('mdc-dialog__footer__button', this.dialog === 'cancel' || this.dialog === 'accept');
-      this.$element.toggleClass('mdc-dialog__footer__button--cancel', this.dialog === 'cancel');
-      this.$element.toggleClass('mdc-dialog__footer__button--accept', this.dialog === 'accept');
+      this.$element.toggleClass(
+        `${DIALOG_BASE_CLASSNAME}__footer__button`,
+        this.dialog === 'cancel' || this.dialog === 'accept'
+      );
+      this.$element.toggleClass(`${DIALOG_BASE_CLASSNAME}__footer__button--cancel`, this.dialog === 'cancel');
+      this.$element.toggleClass(`${DIALOG_BASE_CLASSNAME}__footer__button--accept`, this.dialog === 'accept');
     }
   };
 }

--- a/src/mdc-button/mdc-button.spec.js
+++ b/src/mdc-button/mdc-button.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('mdc-button', function() {
+describe('lmdc-button', function() {
   let MockButton;
 
   beforeEach(angular.mock.module('mdc'));
@@ -11,19 +11,19 @@ describe('mdc-button', function() {
   }));
 
   ['dense', 'raised', 'compact', 'unelevated', 'stroked'].forEach(function(attr) {
-    it('should have the `mdc-button--' + attr + '` class when ' + attr + '=true', function() {
+    it('should have the `lmdc-button--' + attr + '` class when ' + attr + '=true', function() {
       const bindings = {};
       bindings[attr] = 'buttonStyle';
 
       const component = new MockButton(bindings, {buttonStyle: undefined});
       const elem = component.$element;
-      expect(elem.hasClass('mdc-button--' + attr)).to.be.false;
+      expect(elem.hasClass('lmdc-button--' + attr)).to.be.false;
 
       component.$parent('buttonStyle', true);
-      expect(elem.hasClass('mdc-button--' + attr)).to.be.true;
+      expect(elem.hasClass('lmdc-button--' + attr)).to.be.true;
 
       component.$parent('buttonStyle', false);
-      expect(elem.hasClass('mdc-button--' + attr)).to.be.false;
+      expect(elem.hasClass('lmdc-button--' + attr)).to.be.false;
     });
   });
 
@@ -31,16 +31,16 @@ describe('mdc-button', function() {
     it('should have proper classes when dialog=' + action, function() {
       const component = new MockButton({'dialog': '{{ action }}'}, {action: undefined});
       const elem = component.$element;
-      expect(elem.hasClass('mdc-dialog__footer__button'), 'has unnecessary dialog footer class').to.be.false;
-      expect(elem.hasClass('mdc-dialog__footer__button--' + action), 'has unnecessary dialog action class').to.be.false;
+      expect(elem.hasClass('lmdc-dialog__footer__button'), 'has unnecessary dialog footer class').to.be.false;
+      expect(elem.hasClass('lmdc-dialog__footer__button--' + action), 'has unnecessary dialog action class').to.be.false;
 
       component.$parent('action', action);
-      expect(elem.hasClass('mdc-dialog__footer__button'), 'missing dialog footer class').to.be.true;
-      expect(elem.hasClass('mdc-dialog__footer__button--' + action), 'missing dialog action class').to.be.true;
+      expect(elem.hasClass('lmdc-dialog__footer__button'), 'missing dialog footer class').to.be.true;
+      expect(elem.hasClass('lmdc-dialog__footer__button--' + action), 'missing dialog action class').to.be.true;
 
       component.$parent('action', '');
-      expect(elem.hasClass('mdc-dialog__footer__button'), 'has unnecessary dialog footer class').to.be.false;
-      expect(elem.hasClass('mdc-dialog__footer__button--' + action), 'has unnecessary dialog action class').to.be.false;
+      expect(elem.hasClass('lmdc-dialog__footer__button'), 'has unnecessary dialog footer class').to.be.false;
+      expect(elem.hasClass('lmdc-dialog__footer__button--' + action), 'has unnecessary dialog action class').to.be.false;
     });
   });
 });

--- a/src/mdc-checkbox/mdc-checkbox.html
+++ b/src/mdc-checkbox/mdc-checkbox.html
@@ -1,12 +1,12 @@
 <input type="checkbox" ng-model="$ctrl.ngModel" name="$ctrl.name" ng-disabled="$ctrl.ngDisabled"
-       ng-attr-id="{{ $ctrl.inputId }}" class="mdc-checkbox__native-control"/>
-<div class="mdc-checkbox__background">
-  <svg class="mdc-checkbox__checkmark"
+       ng-attr-id="{{ $ctrl.inputId }}" class="lmdc-checkbox__native-control"/>
+<div class="lmdc-checkbox__background">
+  <svg class="lmdc-checkbox__checkmark"
        viewBox="0 0 24 24">
-    <path class="mdc-checkbox__checkmark-path"
+    <path class="lmdc-checkbox__checkmark-path"
           fill="none"
           stroke="white"
           d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
   </svg>
-  <div class="mdc-checkbox__mixedmark"></div>
+  <div class="lmdc-checkbox__mixedmark"></div>
 </div>

--- a/src/mdc-checkbox/mdc-checkbox.js
+++ b/src/mdc-checkbox/mdc-checkbox.js
@@ -1,10 +1,16 @@
 import {arrayUnion} from '../util/array-union';
 import {BaseComponent} from '../util/base-component';
+import {replaceFoundationConstants} from '../util/replace-foundation-constants';
+import {replaceMdcClassname} from '../util/replace-mdc-classname';
 import {IsFormFieldChild} from '../mdc-form-field/child-mixin';
 
-import {MDCCheckbox} from '@material/checkbox';
+import {MDCCheckbox, MDCCheckboxFoundation} from '@material/checkbox';
 
 import template from './mdc-checkbox.html';
+
+const BASE_CLASSNAME = replaceMdcClassname('mdc-checkbox');
+const DISABLED_CLASSNAME = `${BASE_CLASSNAME}--disabled`;
+replaceFoundationConstants(MDCCheckboxFoundation);
 
 
 /**
@@ -42,7 +48,7 @@ export class MDCCheckboxController extends IsFormFieldChild(BaseComponent) {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-checkbox');
+    this.$element.addClass(BASE_CLASSNAME);
     this.mdc = new MDCCheckbox(this.$element[0]);
 
     this.$element.ready(() => {
@@ -55,7 +61,7 @@ export class MDCCheckboxController extends IsFormFieldChild(BaseComponent) {
 
     // inputId is handled by IsFormFieldChild
     if (changesObj.ngDisabled) {
-      this.$element.toggleClass('mdc-checkbox--disabled', Boolean(this.ngDisabled));
+      this.$element.toggleClass(replaceMdcClassname(DISABLED_CLASSNAME), Boolean(this.ngDisabled));
     }
     if (changesObj.indeterminate) {
       this.mdc.indeterminate = this.indeterminate;

--- a/src/mdc-checkbox/mdc-checkbox.js
+++ b/src/mdc-checkbox/mdc-checkbox.js
@@ -61,7 +61,7 @@ export class MDCCheckboxController extends IsFormFieldChild(BaseComponent) {
 
     // inputId is handled by IsFormFieldChild
     if (changesObj.ngDisabled) {
-      this.$element.toggleClass(replaceMdcClassname(DISABLED_CLASSNAME), Boolean(this.ngDisabled));
+      this.$element.toggleClass(DISABLED_CLASSNAME, Boolean(this.ngDisabled));
     }
     if (changesObj.indeterminate) {
       this.mdc.indeterminate = this.indeterminate;

--- a/src/mdc-dialog/component/body.js
+++ b/src/mdc-dialog/component/body.js
@@ -1,4 +1,7 @@
 import {BaseComponent} from '../../util/base-component';
+import {BASE_CLASSNAME as DIALOG_BASE_CLASSNAME} from './dialog';
+
+const SCROLLABLE_BODY_CLASSNAME = `${DIALOG_BASE_CLASSNAME}__body--scrollable`;
 
 /**
  * @ngdoc component
@@ -24,7 +27,7 @@ export class MDCDialogBodyController extends BaseComponent {
 
   $onChanges(changes) {
     if (changes.scrollable) {
-      this.$element.toggleClass('mdc-dialog__body--scrollable', Boolean(this.scrollable));
+      this.$element.toggleClass(SCROLLABLE_BODY_CLASSNAME, Boolean(this.scrollable));
     }
   }
 }

--- a/src/mdc-dialog/component/dialog.html
+++ b/src/mdc-dialog/component/dialog.html
@@ -1,2 +1,2 @@
-<div class="mdc-dialog__surface" ng-transclude></div>
-<div class="mdc-dialog__backdrop"></div>
+<div class="lmdc-dialog__surface" ng-transclude></div>
+<div class="lmdc-dialog__backdrop"></div>

--- a/src/mdc-dialog/component/dialog.js
+++ b/src/mdc-dialog/component/dialog.js
@@ -1,4 +1,8 @@
+import {replaceMdcClassname} from '../../util/replace-mdc-classname';
 import template from './dialog.html';
+
+
+export const BASE_CLASSNAME = replaceMdcClassname('mdc-dialog');
 
 /**
  * @ngdoc component

--- a/src/mdc-dialog/mdc-dialog.spec.js
+++ b/src/mdc-dialog/mdc-dialog.spec.js
@@ -86,16 +86,16 @@ describe('mdc-dialog-body', function() {
     $mockComponent = $componentGenerator('mdcDialogBody');
   }));
 
-  it('should have the `mdc-dialog__body--scrollable` class when scrollable=true', function() {
+  it('should have the `lmdc-dialog__body--scrollable` class when scrollable=true', function() {
     const component = new $mockComponent({'scrollable': 'hasScroll'}, {hasScroll: false});
     const elem = component.$element;
 
-    expect(elem.hasClass('mdc-dialog__body--scrollable')).to.be.false;
+    expect(elem.hasClass('lmdc-dialog__body--scrollable')).to.be.false;
 
     component.$parent('hasScroll', true);
-    expect(elem.hasClass('mdc-dialog__body--scrollable')).to.be.true;
+    expect(elem.hasClass('lmdc-dialog__body--scrollable')).to.be.true;
 
     component.$parent('hasScroll', false);
-    expect(elem.hasClass('mdc-dialog__body--scrollable')).to.be.false;
+    expect(elem.hasClass('lmdc-dialog__body--scrollable')).to.be.false;
   });
 });

--- a/src/mdc-dialog/service/$mdcDialog.js
+++ b/src/mdc-dialog/service/$mdcDialog.js
@@ -1,6 +1,10 @@
+import {replaceFoundationConstants} from '../../util/replace-foundation-constants';
+
 import {MDCDialog, MDCDialogFoundation} from '@material/dialog';
 
 import defaultTemplate from './default-template.html';
+
+replaceFoundationConstants(MDCDialogFoundation);
 
 
 /**

--- a/src/mdc-dialog/service/default-template.html
+++ b/src/mdc-dialog/service/default-template.html
@@ -5,10 +5,10 @@
   <mdc-dialog-header>
     <mdc-dialog-title id="mdc-dialog-title">{{ dialog.title }}</mdc-dialog-title>
   </mdc-dialog-header>
-  <mdc-dialog-body id="mdc-dialog-body" ng-class="::{'mdc-dialog__body--scrollable': dialog.scrollable}"
+  <mdc-dialog-body id="mdc-dialog-body" ng-class="::{'lmdc-dialog__body--scrollable': dialog.scrollable}"
                    ng-if="::dialog.mdcHtmlContent" ng-bind-html="::dialog.mdcHtmlContent">
   </mdc-dialog-body>
-  <mdc-dialog-body id="mdc-dialog-body" ng-class="::{'mdc-dialog__body--scrollable': dialog.scrollable}"
+  <mdc-dialog-body id="mdc-dialog-body" ng-class="::{'lmdc-dialog__body--scrollable': dialog.scrollable}"
                    ng-if="::!dialog.mdcHtmlContent">
     <span ng-if="::dialog.mdcTextContent">{{::dialog.mdcTextContent}}</span>
     <label ng-if="::dialog.$type == 'prompt'">

--- a/src/mdc-form-field/component.js
+++ b/src/mdc-form-field/component.js
@@ -1,6 +1,12 @@
 import {BaseComponent} from '../util/base-component';
+import {replaceMdcClassname} from '../util/replace-mdc-classname';
+import {replaceFoundationConstants} from '../util/replace-foundation-constants';
 
-import {MDCFormField} from '@material/form-field';
+import {MDCFormField, MDCFormFieldFoundation} from '@material/form-field';
+
+const BASE_CLASSNAME = replaceMdcClassname('mdc-form-field');
+const ALIGN_END_CLASSNAME = `${BASE_CLASSNAME}--align-end`;
+replaceFoundationConstants(MDCFormFieldFoundation);
 
 
 /**
@@ -28,12 +34,12 @@ export class MDCFormFieldController extends BaseComponent {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-form-field');
+    this.$element.addClass(BASE_CLASSNAME);
   }
 
   $onChanges(changesObj) {
     if (changesObj.alignEnd) {
-      this.$element.toggleClass('mdc-form-field--align-end', Boolean(this.alignEnd));
+      this.$element.toggleClass(ALIGN_END_CLASSNAME, Boolean(this.alignEnd));
     }
   }
 

--- a/src/mdc-grid-list/mdc-grid-list.html
+++ b/src/mdc-grid-list/mdc-grid-list.html
@@ -1,1 +1,1 @@
-<div class="mdc-grid-list__tiles" ng-transclude></div>
+<div class="lmdc-grid-list__tiles" ng-transclude></div>

--- a/src/mdc-grid-list/mdc-grid-list.js
+++ b/src/mdc-grid-list/mdc-grid-list.js
@@ -1,9 +1,19 @@
 import {BaseComponent} from '../util/base-component';
+import {replaceFoundationConstants} from '../util/replace-foundation-constants';
+import {replaceMdcClassname} from '../util/replace-mdc-classname';
 
 import {MDCGridListFoundation} from '@material/grid-list';
 
 import template from './mdc-grid-list.html';
+
 const VALID_TILE_ASPECTS = ['1x1', '16x9', '2x3', '3x2', '4x3', '3x4'];
+
+const BASE_CLASSNAME = replaceMdcClassname('mdc-grid-list');
+const START_ALIGN_ICON_CLASSNAME = `${BASE_CLASSNAME}--with-icon-align-start`;
+const END_ALIGN_ICON_CLASSNAME = `${BASE_CLASSNAME}--with-icon-align-end`;
+const WITH_GUTTER_CLASSNAME = `${BASE_CLASSNAME}--tile-gutter-1`;
+const TILE_ASPECT_BASE_CLASSNAME = `${BASE_CLASSNAME}--tile-aspect`;
+replaceFoundationConstants(MDCGridListFoundation);
 
 
 /**
@@ -72,15 +82,15 @@ class MDCGridListController extends BaseComponent {
 
   $onChanges(changesObj) {
     if (changesObj.iconAlign) {
-      this.$element.toggleClass('mdc-grid-list--with-icon-align-start', this.iconAlign === 'start');
-      this.$element.toggleClass('mdc-grid-list--with-icon-align-end', this.iconAlign === 'end');
+      this.$element.toggleClass(START_ALIGN_ICON_CLASSNAME, this.iconAlign === 'start');
+      this.$element.toggleClass(END_ALIGN_ICON_CLASSNAME, this.iconAlign === 'end');
     }
     if (changesObj.gutter) {
-      this.$element.toggleClass('mdc-grid-list--tile-gutter-1', this.gutter == '1');
+      this.$element.toggleClass(WITH_GUTTER_CLASSNAME, this.gutter == '1');
     }
     if (changesObj.aspect) {
       VALID_TILE_ASPECTS.forEach((r) => {
-        this.$element.toggleClass('mdc-grid-list--tile-aspect-' + r, this.aspect === r);
+        this.$element.toggleClass(`${TILE_ASPECT_BASE_CLASSNAME}-${r}`, this.aspect === r);
       });
     }
   };

--- a/src/mdc-grid-list/mdc-grid-list.spec.js
+++ b/src/mdc-grid-list/mdc-grid-list.spec.js
@@ -11,47 +11,47 @@ describe('mdc-grid-list', function() {
   }));
 
   ['1x1', '16x9', '2x3', '3x2', '4x3', '3x4'].forEach((aspect) => {
-    it(`should apply the mdc-grid-list--tile-aspect-${aspect} class when aspect=${aspect}`, () => {
+    it(`should apply the lmdc-grid-list--tile-aspect-${aspect} class when aspect=${aspect}`, () => {
       const component = new $mockComponent({'aspect': '{{ tileAspect }}'}, {tileAspect: ''});
       const elem = component.$element;
 
-      expect(elem.hasClass(`mdc-grid-list--tile-aspect-${aspect}`)).to.be.false;
+      expect(elem.hasClass(`lmdc-grid-list--tile-aspect-${aspect}`)).to.be.false;
 
       component.$parent('tileAspect', aspect);
-      expect(elem.hasClass(`mdc-grid-list--tile-aspect-${aspect}`)).to.be.true;
+      expect(elem.hasClass(`lmdc-grid-list--tile-aspect-${aspect}`)).to.be.true;
 
       component.$parent('tileAspect', '');
-      expect(elem.hasClass(`mdc-grid-list--tile-aspect-${aspect}`)).to.be.false;
+      expect(elem.hasClass(`lmdc-grid-list--tile-aspect-${aspect}`)).to.be.false;
     });
   });
 
   ['start', 'end'].forEach((iconAlign) => {
-    it(`should apply the mdc-grid-list--icon-align-${iconAlign} class when iconAlign=${iconAlign}`, () => {
+    it(`should apply the lmdc-grid-list--icon-align-${iconAlign} class when iconAlign=${iconAlign}`, () => {
       const component = new $mockComponent({'iconAlign': '{{ iconAlign }}'}, {iconAlign: ''});
       const elem = component.$element;
 
-      expect(elem.hasClass(`mdc-grid-list--with-icon-align-${iconAlign}`)).to.be.false;
+      expect(elem.hasClass(`lmdc-grid-list--with-icon-align-${iconAlign}`)).to.be.false;
 
       component.$parent('iconAlign', iconAlign);
-      expect(elem.hasClass(`mdc-grid-list--with-icon-align-${iconAlign}`)).to.be.true;
+      expect(elem.hasClass(`lmdc-grid-list--with-icon-align-${iconAlign}`)).to.be.true;
 
       component.$parent('iconAlign', '');
-      expect(elem.hasClass(`mdc-grid-list--with-icon-align-${iconAlign}`)).to.be.false;
+      expect(elem.hasClass(`lmdc-grid-list--with-icon-align-${iconAlign}`)).to.be.false;
     });
   });
 
   ['1'].forEach((tileGutter) => {
-    it(`should apply the mdc-grid-list--tile-gutter-${tileGutter} class when gutter=${tileGutter}`, () => {
+    it(`should apply the lmdc-grid-list--tile-gutter-${tileGutter} class when gutter=${tileGutter}`, () => {
       const component = new $mockComponent({'gutter': '{{ gutter }}'}, {gutter: ''});
       const elem = component.$element;
 
-      expect(elem.hasClass(`mdc-grid-list--tile-gutter-${tileGutter}`)).to.be.false;
+      expect(elem.hasClass(`lmdc-grid-list--tile-gutter-${tileGutter}`)).to.be.false;
 
       component.$parent('gutter', tileGutter);
-      expect(elem.hasClass(`mdc-grid-list--tile-gutter-${tileGutter}`)).to.be.true;
+      expect(elem.hasClass(`lmdc-grid-list--tile-gutter-${tileGutter}`)).to.be.true;
 
       component.$parent('gutter', '');
-      expect(elem.hasClass(`mdc-grid-list--tile-gutter-${tileGutter}`)).to.be.false;
+      expect(elem.hasClass(`lmdc-grid-list--tile-gutter-${tileGutter}`)).to.be.false;
     });
   });
 });

--- a/src/mdc-icon-toggle/mdc-icon-toggle.js
+++ b/src/mdc-icon-toggle/mdc-icon-toggle.js
@@ -1,9 +1,14 @@
 import {directiveNormalize, convertStringsObjToBindingNames} from '../util/normalize';
+import {replaceFoundationConstants} from '../util/replace-foundation-constants';
+import {replaceMdcClassname} from '../util/replace-mdc-classname';
 import {BaseComponent} from '../util/base-component';
 
 import {MDCIconToggleFoundation} from '@material/icon-toggle';
 import {MDCRipple, MDCRippleFoundation} from '@material/ripple';
 
+replaceFoundationConstants(MDCIconToggleFoundation);
+
+const BASE_CLASSNAME = replaceMdcClassname('mdc-icon-toggle');
 
 const bindings = {};
 const STRING_BINDINGS = convertStringsObjToBindingNames(MDCIconToggleFoundation.strings, ['CHANGE_EVENT']);
@@ -57,7 +62,7 @@ export class MDCIconToggleController extends BaseComponent {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-icon-toggle');
+    this.$element.addClass(BASE_CLASSNAME);
     this.$element.attr('tabindex', 0);
     this.$element.ready(() => {
       this.ripple_ = this.initRipple_();

--- a/src/mdc-icon-toggle/mdc-icon-toggle.spec.js
+++ b/src/mdc-icon-toggle/mdc-icon-toggle.spec.js
@@ -138,7 +138,7 @@ describe('mdc-icon-toggle', function() {
 
   function expectComponentToBeDisabled(component) {
     const elem = component.$element;
-    expect(elem.hasClass('mdc-icon-toggle--disabled')).to.be.true;
+    expect(elem.hasClass('lmdc-icon-toggle--disabled')).to.be.true;
     expect(elem.attr('aria-disabled')).to.equal('true');
     expect(elem.attr('tabindex')).to.equal('-1');
     expect(component.$ctrl.ariaDisabled).to.equal('true');
@@ -146,7 +146,7 @@ describe('mdc-icon-toggle', function() {
 
   function expectComponentToBeEnabled(component) {
     const elem = component.$element;
-    expect(elem.hasClass('mdc-icon-toggle--disabled')).to.be.false;
+    expect(elem.hasClass('lmdc-icon-toggle--disabled')).to.be.false;
     expect(elem.attr('aria-disabled')).to.not.exist;
     expect(elem.attr('disabled')).to.not.exist;
     expect(component.$ctrl.ariaDisabled).to.not.exist;

--- a/src/mdc-icon/mdc-icon.js
+++ b/src/mdc-icon/mdc-icon.js
@@ -1,4 +1,7 @@
 import {BaseComponent} from '../util/base-component';
+import {BASE_CLASSNAME as TEXT_FIELD_BASE_CLASSNAME} from '../mdc-text-field/text-field/component';
+
+const TEXT_FIELD_ICON_CLASSNAME = `${TEXT_FIELD_BASE_CLASSNAME}__icon`;
 
 /**
  * @ngdoc component
@@ -55,7 +58,7 @@ export class MDCIconController extends BaseComponent {
       ctrl.toggleIconCtrl(this, true);
     }
 
-    this.$element.toggleClass('mdc-text-field__icon', Boolean(ctrl));
+    this.$element.toggleClass(TEXT_FIELD_ICON_CLASSNAME, Boolean(ctrl));
   }
 
   $onDestroy() {

--- a/src/mdc-list/item/directive.js
+++ b/src/mdc-list/item/directive.js
@@ -1,4 +1,7 @@
 import {BaseComponent} from '../../util/base-component';
+import {replaceMdcClassname} from '../../util/replace-mdc-classname';
+
+const BASE_CLASSNAME = replaceMdcClassname('mdc-list-item');
 
 /**
  * @ngdoc directive
@@ -22,7 +25,7 @@ export class MDCListItemController extends BaseComponent {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-list-item');
+    this.$element.addClass(BASE_CLASSNAME);
     this.$element.attr('role', 'listitem');
   }
 }

--- a/src/mdc-list/list/component.js
+++ b/src/mdc-list/list/component.js
@@ -1,4 +1,12 @@
 import {BaseComponent} from '../../util/base-component';
+import {replaceMdcClassname} from '../../util/replace-mdc-classname';
+
+const BASE_CLASSNAME = replaceMdcClassname('mdc-list');
+const DENSE_CLASSNAME = `${BASE_CLASSNAME}--dense`;
+const AVATAR_LIST_CLASSNAME = `${BASE_CLASSNAME}--avatar-list`;
+const TWO_LINE_CLASSNAME = `${BASE_CLASSNAME}--two-line`;
+const NON_INTERACTIVE_CLASSNAME = `${BASE_CLASSNAME}--non-interactive`;
+
 
 /**
  * @ngdoc component
@@ -31,22 +39,22 @@ export class MDCListController extends BaseComponent {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-list');
+    this.$element.addClass(BASE_CLASSNAME);
     this.$element.attr('role', 'list');
   }
 
   $onChanges(changes) {
     if (changes.dense) {
-      this.$element.toggleClass('mdc-list--dense', Boolean(this.dense));
+      this.$element.toggleClass(DENSE_CLASSNAME, Boolean(this.dense));
     }
     if (changes.avatar) {
-      this.$element.toggleClass('mdc-list--avatar-list', Boolean(this.avatar));
+      this.$element.toggleClass(AVATAR_LIST_CLASSNAME, Boolean(this.avatar));
     }
     if (changes.twoLine) {
-      this.$element.toggleClass('mdc-list--two-line', Boolean(this.twoLine));
+      this.$element.toggleClass(TWO_LINE_CLASSNAME, Boolean(this.twoLine));
     }
     if (changes.nonInteractive) {
-      this.$element.toggleClass('mdc-list--non-interactive', Boolean(this.nonInteractive));
+      this.$element.toggleClass(NON_INTERACTIVE_CLASSNAME, Boolean(this.nonInteractive));
     }
   };
 }

--- a/src/mdc-list/mdc-list.spec.js
+++ b/src/mdc-list/mdc-list.spec.js
@@ -12,7 +12,7 @@ describe('mdc-list', function() {
 
   ['dense', 'twoLine'].forEach(function(style) {
     it('should add the proper class when ' + style + '=true', inject(function($camelToKebab) {
-      const className = 'mdc-list--' + $camelToKebab(style);
+      const className = 'lmdc-list--' + $camelToKebab(style);
       const bindings = {};
       bindings[style] = 'hasStyle';
       const component = new $mockComponent(bindings, {'hasStyle': false});
@@ -28,7 +28,7 @@ describe('mdc-list', function() {
   });
 
   it('should add the proper class when avatar=true', function() {
-    const className = 'mdc-list--avatar-list';
+    const className = 'lmdc-list--avatar-list';
     const component = new $mockComponent({'avatar': 'hasStyle'}, {'hasStyle': false});
     const elem = component.$element;
     expect(elem.hasClass(className)).to.be.false;

--- a/src/mdc-menu/anchor/directive.js
+++ b/src/mdc-menu/anchor/directive.js
@@ -1,5 +1,8 @@
 import {BaseComponent} from '../../util/base-component';
+import {replaceMdcClassname} from '../../util/replace-mdc-classname';
 
+
+const BASE_CLASSNAME = replaceMdcClassname('mdc-menu-anchor');
 
 /**
  * @ngdoc directive
@@ -20,7 +23,7 @@ export class MDCMenuAnchorController extends BaseComponent {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-menu-anchor');
+    this.$element.addClass(BASE_CLASSNAME);
   }
 
   getDimensions() {

--- a/src/mdc-menu/item/component.js
+++ b/src/mdc-menu/item/component.js
@@ -1,7 +1,12 @@
 import {BaseComponent} from '../../util/base-component';
+import {replaceFoundationConstants} from '../../util/replace-foundation-constants';
+import {replaceMdcClassname} from '../../util/replace-mdc-classname';
 import {MDCMenuController} from '../menu/component';
 
 import {MDCMenuFoundation} from '@material/menu';
+
+const BASE_CLASSNAME = replaceMdcClassname('mdc-list-item');
+replaceFoundationConstants(MDCMenuFoundation);
 
 
 /**
@@ -48,7 +53,7 @@ export class MDCMenuItemController extends BaseComponent {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-list-item');
+    this.$element.addClass(BASE_CLASSNAME);
     this.$element.attr('role', 'menuitem');
 
     this.selectHandler = ({detail: {index, item}}) => {

--- a/src/mdc-menu/mdc-menu.spec.js
+++ b/src/mdc-menu/mdc-menu.spec.js
@@ -23,10 +23,10 @@ describe('mdc-menu', () => {
     $rootScope = _$rootScope_;
   }));
 
-  it('should have the `mdc-menu` class', () => {
+  it('should have the `lmdc-menu` class', () => {
     const menu = getMockMenu();
 
-    expect(menu.$element.hasClass('mdc-menu')).to.be.true;
+    expect(menu.$element.hasClass('lmdc-menu')).to.be.true;
 
     return menu.ready;
   });
@@ -51,10 +51,10 @@ describe('mdc-menu', () => {
     const menu = getMockMenu({id: 'menu'});
     const elem = menu.$element;
 
-    expect(elem.hasClass('mdc-menu--animating-open')).to.be.false;
+    expect(elem.hasClass('lmdc-menu--animating-open')).to.be.false;
 
     $rootScope.$broadcast(MDC_MENU_TOGGLE_EVENT, {id: 'menu'});
-    expect(elem.hasClass('mdc-menu--animating-open')).to.be.true;
+    expect(elem.hasClass('lmdc-menu--animating-open')).to.be.true;
 
     return menu.ready;
   });
@@ -63,10 +63,10 @@ describe('mdc-menu', () => {
     const menu = getMockMenu({id: 'menu'});
     const elem = menu.$element;
 
-    expect(elem.hasClass('mdc-menu--animating-open')).to.be.false;
+    expect(elem.hasClass('lmdc-menu--animating-open')).to.be.false;
 
     $rootScope.$broadcast(MDC_MENU_TOGGLE_EVENT, {id: 'notmenu'});
-    expect(elem.hasClass('mdc-menu--animating-open')).to.be.false;
+    expect(elem.hasClass('lmdc-menu--animating-open')).to.be.false;
 
     return menu.ready;
   });
@@ -83,10 +83,10 @@ describe('mdc-menu-anchor', () => {
     MockAnchor = $componentGenerator('mdcMenuAnchor');
   }));
 
-  it('should have the `mdc-menu-anchor` class', () => {
+  it('should have the `lmdc-menu-anchor` class', () => {
     const menu = new MockAnchor();
 
-    expect(menu.$element.hasClass('mdc-menu-anchor')).to.be.true;
+    expect(menu.$element.hasClass('lmdc-menu-anchor')).to.be.true;
   });
 });
 
@@ -114,12 +114,12 @@ describe('mdc-menu-toggle', () => {
 
     $scope.$digest();
 
-    expect(menu1.hasClass('mdc-menu--animating-open')).to.be.false;
-    expect(menu2.hasClass('mdc-menu--animating-open')).to.be.false;
+    expect(menu1.hasClass('lmdc-menu--animating-open')).to.be.false;
+    expect(menu2.hasClass('lmdc-menu--animating-open')).to.be.false;
 
     toggle.triggerHandler('click');
-    expect(menu1.hasClass('mdc-menu--animating-open')).to.be.true;
-    expect(menu2.hasClass('mdc-menu--animating-open')).to.be.false;
+    expect(menu1.hasClass('lmdc-menu--animating-open')).to.be.true;
+    expect(menu2.hasClass('lmdc-menu--animating-open')).to.be.false;
 
     return ready;
   });
@@ -136,10 +136,10 @@ describe('mdc-menu-toggle', () => {
 
     $scope.$digest();
 
-    expect(menu.hasClass('mdc-menu--animating-open')).to.be.false;
+    expect(menu.hasClass('lmdc-menu--animating-open')).to.be.false;
 
     toggle.triggerHandler('click');
-    expect(menu.hasClass('mdc-menu--animating-open')).to.be.true;
+    expect(menu.hasClass('lmdc-menu--animating-open')).to.be.true;
 
     return ready;
   });

--- a/src/mdc-menu/menu/component.js
+++ b/src/mdc-menu/menu/component.js
@@ -1,4 +1,6 @@
 import {arrayUnion} from '../../util/array-union';
+import {replaceMdcClassname} from '../../util/replace-mdc-classname';
+import {replaceFoundationConstants} from '../../util/replace-foundation-constants';
 
 import {MDCComponentNg} from '../../mdc-base/component-ng';
 
@@ -16,6 +18,10 @@ const CORNER_PROPERTY_REGEX = /([ -])/;
 function convertToCornerProperty(anchorFrom) {
   return anchorFrom.replace(CORNER_PROPERTY_REGEX, '_').toUpperCase();
 }
+
+replaceFoundationConstants(MDCMenuFoundation);
+const BASE_CLASSNAME = replaceMdcClassname('mdc-menu');
+export const ITEMS_SELECTOR = replaceMdcClassname('.mdc-list-item[role]');
 
 
 /**
@@ -67,7 +73,7 @@ export class MDCMenuController extends MDCComponentNg {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-menu');
+    this.$element.addClass(BASE_CLASSNAME);
     this.itemControllers = [];
   }
 
@@ -161,7 +167,7 @@ export class MDCMenuController extends MDCComponentNg {
    */
   get items() {
     const {itemsContainer_: itemsContainer} = this;
-    return [].slice.call(itemsContainer.querySelectorAll('.mdc-list-item[role]'));
+    return [].slice.call(itemsContainer.querySelectorAll(ITEMS_SELECTOR));
   }
 
   /** @return {!MDCMenuFoundation} */

--- a/src/mdc-menu/menu/mdc-menu.html
+++ b/src/mdc-menu/menu/mdc-menu.html
@@ -1,1 +1,1 @@
-<div class="mdc-menu__items mdc-list" role="menu" aria-hidden="true" ng-transclude></div>
+<div class="lmdc-menu__items lmdc-list" role="menu" aria-hidden="true" ng-transclude></div>

--- a/src/mdc-radio/mdc-radio.html
+++ b/src/mdc-radio/mdc-radio.html
@@ -1,6 +1,6 @@
-<input class="mdc-radio__native-control" type="radio" ng-attr-id="{{ $ctrl.inputId }}"
+<input class="lmdc-radio__native-control" type="radio" ng-attr-id="{{ $ctrl.inputId }}"
        ng-value="$ctrl.ngValue" ng-disabled="$ctrl.ngDisabled" ng-model="$ctrl.ngModel">
-<div class="mdc-radio__background">
-  <div class="mdc-radio__outer-circle"></div>
-  <div class="mdc-radio__inner-circle"></div>
+<div class="lmdc-radio__background">
+  <div class="lmdc-radio__outer-circle"></div>
+  <div class="lmdc-radio__inner-circle"></div>
 </div>

--- a/src/mdc-radio/mdc-radio.js
+++ b/src/mdc-radio/mdc-radio.js
@@ -1,10 +1,15 @@
 import {arrayUnion} from '../util/array-union';
 import {BaseComponent} from '../util/base-component';
+import {replaceFoundationConstants} from '../util/replace-foundation-constants';
+import {replaceMdcClassname} from '../util/replace-mdc-classname';
 import {IsFormFieldChild} from '../mdc-form-field/child-mixin';
 
-import {MDCRadio} from '@material/radio';
+import {MDCRadio, MDCRadioFoundation} from '@material/radio';
 
 import template from './mdc-radio.html';
+
+const BASE_CLASSNAME = replaceMdcClassname('mdc-radio');
+replaceFoundationConstants(MDCRadioFoundation);
 
 
 /**
@@ -44,7 +49,7 @@ class MDCRadioController extends IsFormFieldChild(BaseComponent) {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-radio');
+    this.$element.addClass(BASE_CLASSNAME);
     this.mdc = new MDCRadio(this.$element[0]);
 
     this.$element.ready(() => {

--- a/src/mdc-radio/mdc-radio.spec.js
+++ b/src/mdc-radio/mdc-radio.spec.js
@@ -10,10 +10,10 @@ describe('mdc-radio', () => {
     MockRadio = $componentGenerator('mdcRadio');
   }));
 
-  it('should have the mdc-radio class', () => {
+  it('should have the lmdc-radio class', () => {
     const radio = new MockRadio();
 
-    expect(radio.$element.hasClass('mdc-radio')).to.be.true;
+    expect(radio.$element.hasClass('lmdc-radio')).to.be.true;
   });
 
   it('should toggle as ng-model changes', function() {
@@ -41,7 +41,7 @@ describe('mdc-radio', () => {
     const elem = component.$element;
     const checkbox = angular.element(component.$element.find('input')[0]);
 
-    expect(elem.hasClass('mdc-radio--disabled')).to.be.true;
+    expect(elem.hasClass('lmdc-radio--disabled')).to.be.true;
     expect(checkbox.attr('disabled')).to.equal('disabled');
   }
 
@@ -49,7 +49,7 @@ describe('mdc-radio', () => {
     const elem = component.$element;
     const checkbox = angular.element(component.$element.find('input')[0]);
 
-    expect(elem.hasClass('mdc-radio--disabled')).to.be.false;
+    expect(elem.hasClass('lmdc-radio--disabled')).to.be.false;
     expect(checkbox.attr('disabled')).to.not.exist;
   }
 

--- a/src/mdc-ripple/directive.js
+++ b/src/mdc-ripple/directive.js
@@ -1,8 +1,10 @@
 import {BaseComponent} from '../util/base-component';
 import {arrayUnion} from '../util/array-union';
+import {replaceMdcClassname} from '../util/replace-mdc-classname';
 
 import {MDCRippleMixin} from './mixin';
 
+const BASE_CLASSNAME = replaceMdcClassname('mdc-ripple-surface');
 
 /**
  * @ngdoc directive
@@ -24,6 +26,6 @@ export class MDCRippleController extends MDCRippleMixin(BaseComponent) {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-ripple-surface');
+    this.$element.addClass(BASE_CLASSNAME);
   }
 }

--- a/src/mdc-ripple/mdc-ripple.spec.js
+++ b/src/mdc-ripple/mdc-ripple.spec.js
@@ -10,10 +10,10 @@ describe('mdc-ripple', () => {
     MockRipple = $componentGenerator('mdcRipple');
   }));
 
-  it('should have the `mdc-ripple-surface` class', () => {
+  it('should have the `lmdc-ripple-surface` class', () => {
     const component = new MockRipple();
     const elem = component.$element;
 
-    expect(elem.hasClass('mdc-ripple-surface'), 'missing class mdc-ripple-surface').to.be.true;
+    expect(elem.hasClass('lmdc-ripple-surface'), 'missing class mdc-ripple-surface').to.be.true;
   });
 });

--- a/src/mdc-ripple/mixin.js
+++ b/src/mdc-ripple/mixin.js
@@ -1,7 +1,10 @@
 import {arrayUnion} from '../util/array-union';
+import {replaceFoundationConstants} from '../util/replace-foundation-constants';
 
-import {MDCRipple} from '@material/ripple';
 
+import {MDCRipple, MDCRippleFoundation} from '@material/ripple';
+
+replaceFoundationConstants(MDCRippleFoundation);
 
 /**
  * Applies a ripple to this.rippleElement and exposes as this.ripple.

--- a/src/mdc-select/item/directive.js
+++ b/src/mdc-select/item/directive.js
@@ -1,6 +1,10 @@
+import {replaceMdcClassname} from '../../util/replace-mdc-classname';
 import {BaseComponent} from '../../util/base-component';
 
 import {MDCSelectController} from '../select/component';
+
+
+const BASE_CLASSNAME = replaceMdcClassname('mdc-list-item');
 
 
 /**
@@ -39,7 +43,7 @@ export class MDCSelectItemController extends BaseComponent {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-list-item');
+    this.$element.addClass(BASE_CLASSNAME);
     this.$element.attr('role', 'option');
 
     if (!this.$element.attr('tabindex')) {

--- a/src/mdc-select/mdc-select.spec.js
+++ b/src/mdc-select/mdc-select.spec.js
@@ -25,17 +25,17 @@ describe('mdc-select', () => {
     MockSelect = $componentGenerator('mdcSelect');
   }));
 
-  it('should have the mdc-select class', () => {
-    expect(new MockSelect().$element.hasClass('mdc-select')).to.be.true;
+  it('should have the lmdc-select class', () => {
+    expect(new MockSelect().$element.hasClass('lmdc-select')).to.be.true;
   });
 
   it('should have attribute role=listbox', () => {
     expect(new MockSelect().$element.attr('role')).to.equal('listbox');
   });
 
-  it('should have class mdc-select--box when box=true', () => {
+  it('should have class lmdc-select--box when box=true', () => {
     const select = new MockSelect({box: true});
-    expect(select.$element.hasClass('mdc-select--box')).to.be.true;
+    expect(select.$element.hasClass('lmdc-select--box')).to.be.true;
   });
 
   it('should toggle between disabled and enabled when ngDisabled changes', () => {
@@ -44,11 +44,11 @@ describe('mdc-select', () => {
 
     return new Promise((resolve) => elem.ready(() => resolve()))
       .then(() => {
-        expect(elem.hasClass('mdc-select--disabled')).to.be.false;
+        expect(elem.hasClass('lmdc-select--disabled')).to.be.false;
         select.$parent('isDisabled', true);
-        expect(elem.hasClass('mdc-select--disabled')).to.be.true;
+        expect(elem.hasClass('lmdc-select--disabled')).to.be.true;
         select.$parent('isDisabled', false);
-        expect(elem.hasClass('mdc-select--disabled')).to.be.false;
+        expect(elem.hasClass('lmdc-select--disabled')).to.be.false;
       });
   });
 
@@ -74,9 +74,9 @@ describe('mdc-select', () => {
 
     return new Promise((resolve) => select.$element.ready(() => resolve()))
       .then(() => {
-        const label = select.$element[0].querySelector('.mdc-select__label');
+        const label = select.$element[0].querySelector('.lmdc-select__label');
 
-        expect(label.classList.contains('mdc-select__label--float-above')).to.be.false;
+        expect(label.classList.contains('lmdc-select__label--float-above')).to.be.false;
       });
   });
 
@@ -85,9 +85,9 @@ describe('mdc-select', () => {
 
     return new Promise((resolve) => select.$element.ready(() => resolve()))
       .then(() => {
-        const label = select.$element[0].querySelector('.mdc-select__label');
+        const label = select.$element[0].querySelector('.lmdc-select__label');
 
-        expect(label.classList.contains('mdc-select__label--float-above')).to.be.true;
+        expect(label.classList.contains('lmdc-select__label--float-above')).to.be.true;
       });
   });
 });
@@ -102,9 +102,9 @@ describe('mdc-select-item', () => {
     MockSelectItem = $componentGenerator('mdcSelectItem');
   }));
 
-  it('should have class mdc-list-item', () => {
+  it('should have class lmdc-list-item', () => {
     const item = new MockSelectItem();
-    expect(item.$element.hasClass('mdc-list-item')).to.be.true;
+    expect(item.$element.hasClass('lmdc-list-item')).to.be.true;
   });
 
   it('should add role="option"', () => {

--- a/src/mdc-select/select/component.js
+++ b/src/mdc-select/select/component.js
@@ -1,12 +1,33 @@
 import {arrayUnion} from '../../util/array-union';
+import {replaceFoundationConstants} from '../../util/replace-foundation-constants';
+import {replaceMdcClassname} from '../../util/replace-mdc-classname';
 import {MDCComponentNg} from '../../mdc-base/component-ng';
 import {MDCRippleMixin} from '../../mdc-ripple/mixin';
+import {ITEMS_SELECTOR} from '../../mdc-menu/menu/component';
 
-import {MDCMenu} from '@material/menu';
+import {MDCMenu, MDCMenuFoundation} from '@material/menu';
 import {MDCSelectFoundation} from '@material/select';
-import {MDCSelectLabel} from '@material/select/label';
+import {MDCSelectLabel, MDCSelectLabelFoundation} from '@material/select/label';
+import {MDCSelectBottomLineFoundation} from '@material/select/bottom-line';
 
 import template from './mdc-select.html';
+
+
+replaceFoundationConstants(MDCSelectFoundation);
+replaceFoundationConstants(MDCSelectLabelFoundation);
+replaceFoundationConstants(MDCSelectBottomLineFoundation);
+replaceFoundationConstants(MDCMenuFoundation);
+
+const BASE_CLASSNAME = replaceMdcClassname('mdc-select');
+const BOX_CLASSNAME = `${BASE_CLASSNAME}--box`;
+
+
+class ModifiedMDCMenu extends MDCMenu {
+  get items() {
+    const {itemsContainer_: itemsContainer} = this;
+    return [].slice.call(itemsContainer.querySelectorAll(ITEMS_SELECTOR));
+  }
+}
 
 
 /**
@@ -58,7 +79,7 @@ export class MDCSelectController extends MDCRippleMixin(MDCComponentNg) {
     super(...args);
 
     this.optionCtrls_ = [];
-    this.$element.addClass('mdc-select');
+    this.$element.addClass(BASE_CLASSNAME);
     this.$element.attr('role', 'listbox');
   }
 
@@ -70,7 +91,7 @@ export class MDCSelectController extends MDCRippleMixin(MDCComponentNg) {
     }
 
     if (changes.box) {
-      this.$element.toggleClass('mdc-select--box', Boolean(this.box));
+      this.$element.toggleClass(BOX_CLASSNAME, Boolean(this.box));
     }
   }
 
@@ -135,7 +156,7 @@ export class MDCSelectController extends MDCRippleMixin(MDCComponentNg) {
     return null;
   }
 
-  initialize(menuFactory = (el) => new MDCMenu(el), labelFactory = (el) => new MDCSelectLabel(el)) {
+  initialize(menuFactory = (el) => new ModifiedMDCMenu(el), labelFactory = (el) => new MDCSelectLabel(el)) {
     this.surface_ = this.root_.querySelector(MDCSelectFoundation.strings.SURFACE_SELECTOR);
     const labelElement = this.root_.querySelector(MDCSelectFoundation.strings.LABEL_SELECTOR);
     if (labelElement) {

--- a/src/mdc-select/select/mdc-select.html
+++ b/src/mdc-select/select/mdc-select.html
@@ -1,8 +1,8 @@
-<div class="mdc-select__surface" tabindex="0">
-  <div class="mdc-select__label" ng-bind="$ctrl.label"></div>
-  <div class="mdc-select__selected-text"></div>
-  <div class="mdc-select__bottom-line"></div>
+<div class="lmdc-select__surface" tabindex="0">
+  <div class="lmdc-select__label" ng-bind="$ctrl.label"></div>
+  <div class="lmdc-select__selected-text"></div>
+  <div class="lmdc-select__bottom-line"></div>
 </div>
-<div class="mdc-menu mdc-select__menu">
-  <ul class="mdc-list mdc-menu__items" ng-transclude></ul>
+<div class="lmdc-menu lmdc-select__menu">
+  <ul class="lmdc-list lmdc-menu__items" ng-transclude></ul>
 </div>

--- a/src/mdc-snackbar/service.js
+++ b/src/mdc-snackbar/service.js
@@ -1,6 +1,7 @@
 import {BindInjections} from '../util/bind-injections';
+import {replaceFoundationConstants} from '../util/replace-foundation-constants';
 
-import {MDCSnackbar} from '@material/snackbar';
+import {MDCSnackbar, MDCSnackbarFoundation} from '@material/snackbar';
 import {numbers} from '@material/snackbar/constants';
 
 import defaultTemplate from './snackbar.html';
@@ -15,6 +16,8 @@ function getParentMap(template) {
   }
   return TEMPLATE_TO_SNACKBAR_MAP.get(template);
 }
+
+replaceFoundationConstants(MDCSnackbarFoundation);
 
 
 /**

--- a/src/mdc-snackbar/snackbar--align-start.html
+++ b/src/mdc-snackbar/snackbar--align-start.html
@@ -1,6 +1,6 @@
-<div class="mdc-snackbar mdc-snackbar--align-start" aria-live="assertive" aria-atomic="true" aria-hidden="true">
-  <div class="mdc-snackbar__text"></div>
-  <div class="mdc-snackbar__action-wrapper">
-    <button type="button" class="mdc-snackbar__action-button"></button>
+<div class="lmdc-snackbar lmdc-snackbar--align-start" aria-live="assertive" aria-atomic="true" aria-hidden="true">
+  <div class="lmdc-snackbar__text"></div>
+  <div class="lmdc-snackbar__action-wrapper">
+    <button type="button" class="lmdc-snackbar__action-button"></button>
   </div>
 </div>

--- a/src/mdc-snackbar/snackbar.html
+++ b/src/mdc-snackbar/snackbar.html
@@ -1,6 +1,6 @@
-<div class="mdc-snackbar" aria-live="assertive" aria-atomic="true" aria-hidden="true">
-  <div class="mdc-snackbar__text"></div>
-  <div class="mdc-snackbar__action-wrapper">
-    <button type="button" class="mdc-snackbar__action-button"></button>
+<div class="lmdc-snackbar" aria-live="assertive" aria-atomic="true" aria-hidden="true">
+  <div class="lmdc-snackbar__text"></div>
+  <div class="lmdc-snackbar__action-wrapper">
+    <button type="button" class="lmdc-snackbar__action-button"></button>
   </div>
 </div>

--- a/src/mdc-switch/mdc-switch.html
+++ b/src/mdc-switch/mdc-switch.html
@@ -1,5 +1,5 @@
-<input type="checkbox" class="mdc-switch__native-control" id="{{ $ctrl.inputId }}"
+<input type="checkbox" class="lmdc-switch__native-control" id="{{ $ctrl.inputId }}"
        ng-disabled="$ctrl.ngDisabled" ng-model="$ctrl.ngModel">
-<div class="mdc-switch__background">
-    <div class="mdc-switch__knob"></div>
+<div class="lmdc-switch__background">
+    <div class="lmdc-switch__knob"></div>
 </div>

--- a/src/mdc-switch/mdc-switch.js
+++ b/src/mdc-switch/mdc-switch.js
@@ -1,10 +1,14 @@
 import {arrayUnion} from '../util/array-union';
+import {replaceMdcClassname} from '../util/replace-mdc-classname';
 
 import {BaseComponent} from '../util/base-component';
 import {IsFormFieldChild} from '../mdc-form-field/child-mixin';
 
 import template from './mdc-switch.html';
 
+
+const BASE_CLASSNAME = replaceMdcClassname('mdc-switch');
+const DISABLED_CLASSNAME = `${BASE_CLASSNAME}--disabled`;
 
 /**
  * @ngdoc component
@@ -38,14 +42,14 @@ export class MDCSwitchController extends IsFormFieldChild(BaseComponent) {
 
   constructor(...args) {
     super(...args);
-    this.$element.addClass('mdc-switch');
+    this.$element.addClass(BASE_CLASSNAME);
   }
 
   $onChanges(changes) {
     super.$onChanges(changes);
 
     if (changes.ngDisabled) {
-      this.$element.toggleClass('mdc-switch--disabled', Boolean(this.ngDisabled));
+      this.$element.toggleClass(DISABLED_CLASSNAME, Boolean(this.ngDisabled));
     }
   };
 }

--- a/src/mdc-switch/mdc-switch.spec.js
+++ b/src/mdc-switch/mdc-switch.spec.js
@@ -10,10 +10,10 @@ describe('mdc-switch', function() {
     $mockComponent = $componentGenerator('mdcSwitch');
   }));
 
-  it('should have the mdc-switch class', () => {
+  it('should have the lmdc-switch class', () => {
     const sw = new $mockComponent();
 
-    expect(sw.$element.hasClass('mdc-switch')).to.be.true;
+    expect(sw.$element.hasClass('lmdc-switch')).to.be.true;
   });
 
   it('should toggle as ng-model changes', function() {
@@ -41,7 +41,7 @@ describe('mdc-switch', function() {
     const elem = component.$element;
     const checkbox = angular.element(component.$element.find('input')[0]);
 
-    expect(elem.hasClass('mdc-switch--disabled')).to.be.true;
+    expect(elem.hasClass('lmdc-switch--disabled')).to.be.true;
     expect(checkbox.attr('disabled')).to.equal('disabled');
   }
 
@@ -49,7 +49,7 @@ describe('mdc-switch', function() {
     const elem = component.$element;
     const checkbox = angular.element(component.$element.find('input')[0]);
 
-    expect(elem.hasClass('mdc-switch--disabled')).to.be.false;
+    expect(elem.hasClass('lmdc-switch--disabled')).to.be.false;
     expect(checkbox.attr('disabled')).to.not.exist;
   }
 

--- a/src/mdc-tabs/tab-bar-scroller.html
+++ b/src/mdc-tabs/tab-bar-scroller.html
@@ -1,11 +1,11 @@
-<div class="mdc-tab-bar-scroller__indicator mdc-tab-bar-scroller__indicator--back">
-  <a class="mdc-tab-bar-scroller__indicator__inner material-icons" href="javascript:void(0)" aria-label="scroll back button">
+<div class="lmdc-tab-bar-scroller__indicator lmdc-tab-bar-scroller__indicator--back">
+  <a class="lmdc-tab-bar-scroller__indicator__inner material-icons" href="javascript:void(0)" aria-label="scroll back button">
     navigate_before
   </a>
 </div>
-<div class="mdc-tab-bar-scroller__scroll-frame" ng-transclude></div>
-<div class="mdc-tab-bar-scroller__indicator mdc-tab-bar-scroller__indicator--forward">
-  <a class="mdc-tab-bar-scroller__indicator__inner material-icons" href="javascript:void(0)" aria-label="scroll forward button">
+<div class="lmdc-tab-bar-scroller__scroll-frame" ng-transclude></div>
+<div class="lmdc-tab-bar-scroller__indicator lmdc-tab-bar-scroller__indicator--forward">
+  <a class="lmdc-tab-bar-scroller__indicator__inner material-icons" href="javascript:void(0)" aria-label="scroll forward button">
     navigate_next
   </a>
 </div>

--- a/src/mdc-tabs/tab-bar-scroller.js
+++ b/src/mdc-tabs/tab-bar-scroller.js
@@ -1,4 +1,6 @@
 import {arrayUnion} from '../util/array-union';
+import {replaceFoundationConstants} from '../util/replace-foundation-constants';
+import {replaceMdcClassname} from '../util/replace-mdc-classname';
 
 import {MDCComponentNg} from '../mdc-base/component-ng';
 
@@ -7,6 +9,9 @@ import {getCorrectPropertyName} from '@material/animation';
 import {MDCTabBarScrollerFoundation} from '@material/tabs/tab-bar-scroller';
 
 import template from './tab-bar-scroller.html';
+
+const BASE_CLASSNAME = replaceMdcClassname('mdc-tab-bar-scroller');
+replaceFoundationConstants(MDCTabBarScrollerFoundation);
 
 
 /**
@@ -35,7 +40,7 @@ export class MDCTabBarScrollerController extends MDCComponentNg {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-tab-bar-scroller');
+    this.$element.addClass(BASE_CLASSNAME);
   }
 
   get tabBar() {

--- a/src/mdc-tabs/tab-bar.js
+++ b/src/mdc-tabs/tab-bar.js
@@ -1,11 +1,22 @@
 import {arrayUnion} from '../util/array-union';
+import {replaceFoundationConstants} from '../util/replace-foundation-constants';
+import {replaceMdcClassname} from '../util/replace-mdc-classname';
 
 import {MDCComponentNg} from '../mdc-base/component-ng';
 
+import {BASE_CLASSNAME as TAB_BASE_CLASSNAME} from './tab';
 import {MDCTabBarScrollerController} from './tab-bar-scroller';
 
 import {MDCTabFoundation, MDCTabBarFoundation} from '@material/tabs';
 
+replaceFoundationConstants(MDCTabBarFoundation);
+replaceFoundationConstants(MDCTabFoundation);
+
+const BASE_CLASSNAME = replaceMdcClassname('mdc-tab-bar');
+const INDICATOR_CLASSNAME = `${BASE_CLASSNAME}__indicator`;
+const ICON_TABS_CLASSNAME = `${BASE_CLASSNAME}--icon-tabs`;
+const ICONS_WITH_TEXT_CLASSNAME = `${BASE_CLASSNAME}--icons-with-text`;
+const SCROLLER_SCROLL_FRAME_TABS_CLASSNAME = `${BASE_CLASSNAME}-scroller__scroll-frame__tabs`;
 
 /**
  * @ngdoc component
@@ -40,16 +51,16 @@ export class MDCTabBarController extends MDCComponentNg {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-tab-bar');
+    this.$element.addClass(BASE_CLASSNAME);
 
-    this.indicator_ = angular.element('<span class="mdc-tab-bar__indicator"></span>')[0];
+    this.indicator_ = angular.element(`<span class="${INDICATOR_CLASSNAME}"></span>`)[0];
     this.$element.append(this.indicator_);
 
     this.tabs_ = []; // tabs will automatically add themselves to the list using .addTab()
   }
 
   get tabElements() {
-    return [].slice.call(this.root_.getElementsByClassName('mdc-tab'));
+    return [].slice.call(this.root_.getElementsByClassName(TAB_BASE_CLASSNAME));
   }
 
   get value() {
@@ -152,7 +163,7 @@ export class MDCTabBarController extends MDCComponentNg {
     super.$postLink();
 
     if (this.scroller) {
-      this.$element.addClass('mdc-tab-bar-scroller__scroll-frame__tabs');
+      this.$element.addClass(SCROLLER_SCROLL_FRAME_TABS_CLASSNAME);
       this.scroller.setTabBar(this);
     }
   }
@@ -169,8 +180,8 @@ export class MDCTabBarController extends MDCComponentNg {
     super.$onChanges(changes);
 
     if (changes.variant) {
-      this.$element.toggleClass('mdc-tab-bar--icon-tabs', this.variant === 'icon');
-      this.$element.toggleClass('mdc-tab-bar--icons-with-text', this.variant === 'icons-text');
+      this.$element.toggleClass(ICON_TABS_CLASSNAME, this.variant === 'icon');
+      this.$element.toggleClass(ICONS_WITH_TEXT_CLASSNAME, this.variant === 'icons-text');
     }
   }
 

--- a/src/mdc-tabs/tab-text.js
+++ b/src/mdc-tabs/tab-text.js
@@ -1,7 +1,9 @@
 import {BaseComponent} from '../util/base-component';
+import {replaceMdcClassname} from '../util/replace-mdc-classname';
 
 import {MDCTabController} from './tab';
 
+const BASE_CLASSNAME = replaceMdcClassname('mdc-tab__icon-text');
 
 /**
  * @ngdoc directive
@@ -31,7 +33,7 @@ export class MDCTabTextController extends BaseComponent {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-tab__icon-text');
+    this.$element.addClass(BASE_CLASSNAME);
   }
 
   $postLink() {

--- a/src/mdc-tabs/tab.js
+++ b/src/mdc-tabs/tab.js
@@ -1,4 +1,6 @@
 import {arrayUnion} from '../util/array-union';
+import {replaceFoundationConstants} from '../util/replace-foundation-constants';
+import {replaceMdcClassname} from '../util/replace-mdc-classname';
 
 import {MDCComponentNg} from '../mdc-base/component-ng';
 import {MDCRippleMixin} from '../mdc-ripple/mixin';
@@ -7,6 +9,9 @@ import {MDCTabBarController} from './tab-bar';
 import {MDCTabFoundation} from '@material/tabs';
 import {HasNgValue} from '../util/has-ng-value-mixin';
 
+export const BASE_CLASSNAME = replaceMdcClassname('mdc-tab');
+const WITH_ICON_AND_TEXT_CLASSNAME = `${BASE_CLASSNAME}--with-icon-and-text`;
+replaceFoundationConstants(MDCTabFoundation);
 
 /**
  * @ngdoc component
@@ -34,7 +39,7 @@ export class MDCTabController extends HasNgValue(MDCRippleMixin(MDCComponentNg))
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass('mdc-tab');
+    this.$element.addClass(BASE_CLASSNAME);
     if (!this.$element.attr('href') && !this.$element.attr('tabindex')) {
       this.$element.attr('tabindex', 0);
     }
@@ -61,7 +66,7 @@ export class MDCTabController extends HasNgValue(MDCRippleMixin(MDCComponentNg))
   }
 
   setMDCText(value) {
-    this.$element.toggleClass('mdc-tab--with-icon-and-text', Boolean(value));
+    this.$element.toggleClass(WITH_ICON_AND_TEXT_CLASSNAME, Boolean(value));
   }
 
   set tabBar(bar) {

--- a/src/mdc-text-field/mdc-text-field.spec.js
+++ b/src/mdc-text-field/mdc-text-field.spec.js
@@ -38,10 +38,10 @@ describe('mdc-text-field', () => {
     return new Promise((resolve) => tf.$element.ready(() => resolve(tf)));
   }
 
-  it('should have the mdc-text-field class', () => {
+  it('should have the lmdc-text-field class', () => {
     return getMockTF()
       .then((tf) => {
-        expect(tf.$element.hasClass('mdc-text-field')).to.be.true;
+        expect(tf.$element.hasClass('lmdc-text-field')).to.be.true;
       });
   });
 
@@ -53,7 +53,7 @@ describe('mdc-text-field', () => {
 
           expect(label[0]).to.exist;
           expect(label.text()).to.equal(LABEL_TEXT);
-          expect(label.hasClass('mdc-floating-label')).to.be.true;
+          expect(label.hasClass('lmdc-floating-label')).to.be.true;
         });
     });
 
@@ -87,10 +87,10 @@ describe('mdc-text-field', () => {
         });
     });
 
-    it('should have a child .mdc-line-ripple', () => {
+    it('should have a child .lmdc-line-ripple', () => {
       return getMockTF()
         .then((tf) => {
-          const lr = tf.$element[0].querySelector('.mdc-line-ripple');
+          const lr = tf.$element[0].querySelector('.lmdc-line-ripple');
 
           expect(lr).to.exist;
         });
@@ -105,17 +105,17 @@ describe('mdc-text-field', () => {
   });
 
   context('child textarea', () => {
-    it('should have the mdc-text-field--textarea class', () => {
+    it('should have the lmdc-text-field--textarea class', () => {
       return getMockTF({}, {}, {textarea: true})
         .then((tf) => {
-          expect(tf.$element.hasClass('mdc-text-field--textarea')).to.be.true;
+          expect(tf.$element.hasClass('lmdc-text-field--textarea')).to.be.true;
         });
     });
 
-    it('should not have a child mdc-line-ripple if contains a textarea', () => {
+    it('should not have a child lmdc-line-ripple if contains a textarea', () => {
       return getMockTF({}, {}, {textarea: true})
         .then((tf) => {
-          const lr = tf.$element[0].querySelector('.mdc-line-ripple');
+          const lr = tf.$element[0].querySelector('.lmdc-line-ripple');
 
           expect(lr).to.not.exist;
         });
@@ -130,10 +130,10 @@ describe('mdc-text-field', () => {
   });
 
   context('fullwidth=true', () => {
-    it('should have mdc-text-field--fullwidth if fullwidth = true', () => {
+    it('should have lmdc-text-field--fullwidth if fullwidth = true', () => {
       return getMockTF({fullwidth: true})
         .then((tf) => {
-          expect(tf.$element.hasClass('mdc-text-field--fullwidth')).to.be.true;
+          expect(tf.$element.hasClass('lmdc-text-field--fullwidth')).to.be.true;
         });
     });
 
@@ -159,7 +159,7 @@ describe('mdc-text-field', () => {
 
           expect(label[0]).to.exist;
           expect(label.text()).to.equal(LABEL_TEXT);
-          expect(label.hasClass('mdc-floating-label')).to.be.true;
+          expect(label.hasClass('lmdc-floating-label')).to.be.true;
         });
     });
 
@@ -182,26 +182,26 @@ describe('mdc-text-field', () => {
   });
 
   context('box=true', () => {
-    it('should have mdc-text-field--box', () => {
+    it('should have lmdc-text-field--box', () => {
       return getMockTF({box: true})
         .then((tf) => {
-          expect(tf.$element.hasClass('mdc-text-field--box')).to.be.true;
+          expect(tf.$element.hasClass('lmdc-text-field--box')).to.be.true;
         });
     });
   });
 
   context('outlined=true', () => {
-    it('should have mdc-text-field--outlined', () => {
+    it('should have lmdc-text-field--outlined', () => {
       return getMockTF({outlined: true})
         .then((tf) => {
-          expect(tf.$element.hasClass('mdc-text-field--outlined')).to.be.true;
+          expect(tf.$element.hasClass('lmdc-text-field--outlined')).to.be.true;
         });
     });
 
-    it('should not have a child mdc-line-ripple', () => {
+    it('should not have a child lmdc-line-ripple', () => {
       return getMockTF({outlined: true})
         .then((tf) => {
-          const lr = tf.$element[0].querySelector('.mdc-line-ripple');
+          const lr = tf.$element[0].querySelector('.lmdc-line-ripple');
 
           expect(lr).to.not.exist;
         });
@@ -214,10 +214,10 @@ describe('mdc-text-field', () => {
         });
     });
 
-    it('should have a child mdc-text-field__outline', () => {
+    it('should have a child lmdc-text-field__outline', () => {
       return getMockTF({outlined: true})
         .then((tf) => {
-          const outline = tf.$element[0].querySelector('.mdc-text-field__outline');
+          const outline = tf.$element[0].querySelector('.lmdc-text-field__outline');
 
           expect(outline).to.exist;
         });
@@ -230,17 +230,17 @@ describe('mdc-text-field', () => {
         });
     });
 
-    it('should not have mdc-text-field--outlined if contains a textarea', () => {
+    it('should not have lmdc-text-field--outlined if contains a textarea', () => {
       return getMockTF({outlined: true}, {}, {textarea: true})
         .then((tf) => {
-          expect(tf.$element.hasClass('mdc-text-field--outlined')).to.be.false;
+          expect(tf.$element.hasClass('lmdc-text-field--outlined')).to.be.false;
         });
     });
 
-    it('should not have a child mdc-text-field__outline if contains a textarea', () => {
+    it('should not have a child lmdc-text-field__outline if contains a textarea', () => {
       return getMockTF({outlined: true}, {}, {textarea: true})
         .then((tf) => {
-          const outline = tf.$element[0].querySelector('.mdc-text-field__outline');
+          const outline = tf.$element[0].querySelector('.lmdc-text-field__outline');
 
           expect(outline).to.not.exist;
         });
@@ -253,28 +253,28 @@ describe('mdc-text-field', () => {
         });
     });
 
-    it('should not have mdc-text-field--box if box=true', () => {
+    it('should not have lmdc-text-field--box if box=true', () => {
       return getMockTF({outlined: true, box: true})
         .then((tf) => {
-          expect(tf.$element.hasClass('mdc-text-field--box')).to.be.false;
+          expect(tf.$element.hasClass('lmdc-text-field--box')).to.be.false;
         });
     });
   });
 
   context('dense=true', () => {
-    it('should have mdc-text-field--dense', () => {
+    it('should have lmdc-text-field--dense', () => {
       return getMockTF({dense: true})
         .then((tf) => {
-          expect(tf.$element.hasClass('mdc-text-field--dense')).to.be.true;
+          expect(tf.$element.hasClass('lmdc-text-field--dense')).to.be.true;
         });
     });
   });
 
   context('with icons', () => {
-    it('should have mdc-text-field--with-leading-icon if icon is before input', () => {
+    it('should have lmdc-text-field--with-leading-icon if icon is before input', () => {
       return getMockTF({outlined: true}, {}, {icon: 'leading'})
         .then((tf) => {
-          expect(tf.$element.hasClass('mdc-text-field--with-leading-icon')).to.be.true;
+          expect(tf.$element.hasClass('lmdc-text-field--with-leading-icon')).to.be.true;
         });
     });
 
@@ -285,10 +285,10 @@ describe('mdc-text-field', () => {
         });
     });
 
-    it('should have mdc-text-field--with-trailing-icon if icon is after input', () => {
+    it('should have lmdc-text-field--with-trailing-icon if icon is after input', () => {
       return getMockTF({outlined: true}, {}, {icon: 'trailing'})
         .then((tf) => {
-          expect(tf.$element.hasClass('mdc-text-field--with-trailing-icon')).to.be.true;
+          expect(tf.$element.hasClass('lmdc-text-field--with-trailing-icon')).to.be.true;
           expect(tf.$ctrl.mdc.icon_).to.exist;
         });
     });
@@ -304,10 +304,10 @@ describe('mdc-text-field', () => {
   context('with helper text', () => {
     const HELP_TEXT = 'Test Help Text';
 
-    it('should create a mdc-text-field-helper-text element', () => {
+    it('should create a lmdc-text-field-helper-text element', () => {
       return getMockTF({helperText: HELP_TEXT})
         .then(() => {
-          const helperTextEl = tfParentEl[0].querySelector('.mdc-text-field-helper-text');
+          const helperTextEl = tfParentEl[0].querySelector('.lmdc-text-field-helper-text');
           expect(tfParentEl.children()[1]).to.equal(helperTextEl);
           expect(helperTextEl).to.exist;
           expect(helperTextEl.textContent).to.equal(HELP_TEXT);
@@ -320,7 +320,7 @@ describe('mdc-text-field', () => {
           const input = tf.$element.find('input')[0];
           expect(input.getAttribute('aria-controls')).to.exist;
 
-          const helperTextEl = tfParentEl[0].querySelector('.mdc-text-field-helper-text');
+          const helperTextEl = tfParentEl[0].querySelector('.lmdc-text-field-helper-text');
           expect(helperTextEl.id).to.exist;
 
           expect(input.getAttribute('aria-controls')).to.equal(helperTextEl.id);
@@ -330,24 +330,24 @@ describe('mdc-text-field', () => {
     it('should have --persistent on helperText if helperTextPersistent = true', () => {
       return getMockTF({helperText: HELP_TEXT, helperTextPersistent: true})
         .then(() => {
-          const helperTextEl = tfParentEl[0].querySelector('.mdc-text-field-helper-text');
+          const helperTextEl = tfParentEl[0].querySelector('.lmdc-text-field-helper-text');
 
-          expect(helperTextEl.classList.contains('mdc-text-field-helper-text--persistent')).to.be.true;
+          expect(helperTextEl.classList.contains('lmdc-text-field-helper-text--persistent')).to.be.true;
         });
     });
 
     it('should have --validation-msg on helperText if helperTextValidation = true', () => {
       return getMockTF({helperText: HELP_TEXT, helperTextValidation: true})
         .then(() => {
-          const helperTextEl = tfParentEl[0].querySelector('.mdc-text-field-helper-text');
+          const helperTextEl = tfParentEl[0].querySelector('.lmdc-text-field-helper-text');
 
-          expect(helperTextEl.classList.contains('mdc-text-field-helper-text--validation-msg')).to.be.true;
+          expect(helperTextEl.classList.contains('lmdc-text-field-helper-text--validation-msg')).to.be.true;
         });
     });
   });
 
   context('disabled', () => {
-    const DISABLED_CLASS = 'mdc-text-field--disabled';
+    const DISABLED_CLASS = 'lmdc-text-field--disabled';
     it(`should have ${DISABLED_CLASS}`, () => {
       return getMockTF({}, {tfDisabled: true})
         .then((tf) => {
@@ -375,7 +375,7 @@ describe('mdc-text-field', () => {
 
   context('model', () => {
     const TEST_VALUE = 'test value';
-    const FLOAT_LABEL = 'mdc-floating-label--float-above';
+    const FLOAT_LABEL = 'lmdc-floating-label--float-above';
 
     it('should update mdc.value when input ng-model changes', () => {
       return getMockTF({}, {tfModel: ''})

--- a/src/mdc-text-field/text-field/component.js
+++ b/src/mdc-text-field/text-field/component.js
@@ -1,8 +1,40 @@
 import {BaseComponent} from '../../util/base-component';
+import {replaceFoundationConstants} from '../../util/replace-foundation-constants';
+import {replaceMdcClassname} from '../../util/replace-mdc-classname';
 
-import {MDCTextField, MDCTextFieldFoundation, MDCTextFieldHelperTextFoundation} from '@material/textfield';
+import {
+  MDCTextField,
+  MDCTextFieldFoundation,
+  MDCTextFieldHelperTextFoundation,
+  MDCTextFieldIconFoundation,
+  MDCTextFieldOutlineFoundation,
+} from '@material/textfield';
+import {MDCLineRippleFoundation} from '@material/line-ripple';
+import {MDCFloatingLabelFoundation} from '@material/floating-label';
 
 import outlineTemplate from './outline.html';
+
+replaceFoundationConstants(MDCTextFieldFoundation);
+replaceFoundationConstants(MDCTextFieldHelperTextFoundation);
+replaceFoundationConstants(MDCLineRippleFoundation);
+replaceFoundationConstants(MDCTextFieldIconFoundation);
+replaceFoundationConstants(MDCTextFieldOutlineFoundation);
+replaceFoundationConstants(MDCFloatingLabelFoundation);
+
+export const BASE_CLASSNAME = MDCTextFieldFoundation.cssClasses.ROOT;
+const TEXTAREA_CLASSNAME = `${BASE_CLASSNAME}--textarea`;
+const FULLWIDTH_CLASSNAME = `${BASE_CLASSNAME}--fullwidth`;
+const WITH_LEADING_ICON_CLASSNAME = `${BASE_CLASSNAME}--with-leading-icon`;
+const WITH_TRAILING_ICON_CLASSNAME = `${BASE_CLASSNAME}--with-trailing-icon`;
+
+const INPUT_CLASSNAME = `${BASE_CLASSNAME}__input`;
+const OUTLINE_CLASSNAME = `${BASE_CLASSNAME}__outline`;
+const IDLE_OUTLINE_CLASSNAME = `${BASE_CLASSNAME}__idle-outline`;
+
+const HELPER_TEXT_CLASSNAME = `${BASE_CLASSNAME}-helper-text`;
+
+const LINE_RIPPLE_CLASSNAME = replaceMdcClassname('mdc-line-ripple');
+const FLOATING_LABEL_CLASSNAME = replaceMdcClassname('mdc-floating-label');
 
 
 /**
@@ -44,7 +76,7 @@ export class MDCTextFieldController extends BaseComponent {
   constructor(...args) {
     super(...args);
 
-    this.$element.addClass(MDCTextFieldFoundation.cssClasses.ROOT);
+    this.$element.addClass(BASE_CLASSNAME);
 
     this.root_ = this.$element[0];
     this.setupInput_();
@@ -106,12 +138,12 @@ export class MDCTextFieldController extends BaseComponent {
     this.inputElement_ = this.root_.querySelector('input,textarea');
 
     if (this.inputElement_.tagName === 'TEXTAREA') {
-      this.root_.classList.add('mdc-text-field--textarea');
+      this.root_.classList.add(TEXTAREA_CLASSNAME);
     } else {
-      this.root_.classList.remove('mdc-text-field--textarea');
+      this.root_.classList.remove(TEXTAREA_CLASSNAME);
     }
 
-    this.inputElement_.classList.add('mdc-text-field__input');
+    this.inputElement_.classList.add(INPUT_CLASSNAME);
 
     if (!this.inputElement_.id) {
       this.inputElement_.id = `--mdc-form-field-${this.$scope.$id}`;
@@ -119,7 +151,7 @@ export class MDCTextFieldController extends BaseComponent {
   }
 
   setupLabelAndFullwidth_() {
-    this.$element.toggleClass('mdc-text-field--fullwidth', Boolean(this.fullwidth));
+    this.$element.toggleClass(FULLWIDTH_CLASSNAME, Boolean(this.fullwidth));
 
     let labelElement = this.root_.getElementsByTagName('label')[0];
 
@@ -131,7 +163,7 @@ export class MDCTextFieldController extends BaseComponent {
         this.inputElement_.insertAdjacentElement('afterend', labelElement);
       }
 
-      labelElement.classList.add('mdc-floating-label');
+      labelElement.classList.add(FLOATING_LABEL_CLASSNAME);
       if (this.label) {
         labelElement.innerText = this.label;
       }
@@ -150,9 +182,9 @@ export class MDCTextFieldController extends BaseComponent {
   }
 
   setupOutlinedAndBox_() {
-    const outlineElement = this.root_.getElementsByClassName('mdc-text-field__outline')[0];
-    const idleOutlineElement = this.root_.getElementsByClassName('mdc-text-field__idle-outline')[0];
-    const bottomLineElement = this.root_.getElementsByClassName('mdc-line-ripple')[0];
+    const outlineElement = this.root_.getElementsByClassName(OUTLINE_CLASSNAME)[0];
+    const idleOutlineElement = this.root_.getElementsByClassName(IDLE_OUTLINE_CLASSNAME)[0];
+    const bottomLineElement = this.root_.getElementsByClassName(LINE_RIPPLE_CLASSNAME)[0];
 
     this.$element.toggleClass(MDCTextFieldFoundation.cssClasses.OUTLINED, Boolean(this.outlined) && !this.isTextArea);
     this.$element.toggleClass(MDCTextFieldFoundation.cssClasses.BOX, !Boolean(this.outlined) && Boolean(this.box));
@@ -174,7 +206,7 @@ export class MDCTextFieldController extends BaseComponent {
     }
 
     if (wantsBottomLine && !bottomLineElement) {
-      this.$element.append('<div class="mdc-line-ripple"></div>');
+      this.$element.append(`<div class="${LINE_RIPPLE_CLASSNAME}"></div>`);
     } else if (!wantsBottomLine && bottomLineElement) {
       bottomLineElement.remove();
     }
@@ -200,7 +232,7 @@ export class MDCTextFieldController extends BaseComponent {
     if (wantsHelpText) {
       if (!this.helperTextElement_) {
         this.helperTextElement_ = this.$document[0].createElement('p');
-        this.helperTextElement_.className = 'mdc-text-field-helper-text';
+        this.helperTextElement_.className = HELPER_TEXT_CLASSNAME;
         this.helperTextElement_.id = `${this.inputElement_.id}--help`;
 
         this.inputElement_.setAttribute('aria-controls', this.helperTextElement_.id);
@@ -254,9 +286,9 @@ export class MDCTextFieldController extends BaseComponent {
     const isLeading = iconCtrl.$element[0] === this.$element.children()[0];
 
     if (isLeading) {
-      this.$element.toggleClass('mdc-text-field--with-leading-icon', enabled);
+      this.$element.toggleClass(WITH_LEADING_ICON_CLASSNAME, enabled);
     } else {
-      this.$element.toggleClass('mdc-text-field--with-trailing-icon', enabled);
+      this.$element.toggleClass(WITH_TRAILING_ICON_CLASSNAME, enabled);
     }
   }
 

--- a/src/mdc-text-field/text-field/outline.html
+++ b/src/mdc-text-field/text-field/outline.html
@@ -1,6 +1,6 @@
-<div class="mdc-text-field__outline">
+<div class="lmdc-text-field__outline">
   <svg>
-    <path class="mdc-text-field__outline-path"></path>
+    <path class="lmdc-text-field__outline-path"></path>
   </svg>
 </div>
-<div class="mdc-text-field__idle-outline"></div>
+<div class="lmdc-text-field__idle-outline"></div>

--- a/src/util/replace-foundation-constants.js
+++ b/src/util/replace-foundation-constants.js
@@ -1,0 +1,21 @@
+import {replaceMdcClassname} from './replace-mdc-classname';
+
+export function replaceFoundationConstants(foundation) {
+  if (foundation.___constantsUpdated) {
+    // don't rerun replacement if it has already occurred
+    return;
+  }
+
+  [foundation.cssClasses, foundation.strings].forEach((obj) => {
+    if (!obj) {
+      return;
+    }
+
+    Object.keys(obj)
+      .forEach((key) => {
+        obj[key] = replaceMdcClassname(obj[key]);
+      });
+  });
+
+  foundation.___constantsUpdated = true;
+}

--- a/src/util/replace-mdc-classname.js
+++ b/src/util/replace-mdc-classname.js
@@ -1,0 +1,14 @@
+
+const MDC_PREFIX_REGEX = /mdc-/;
+
+/**
+ * @param {string} className
+ * @returns {string}
+ */
+export function replaceMdcClassname(className) {
+  if (className.startsWith('--') || className.includes('lmdc-')) {
+    return className;
+  }
+
+  return className.replace(MDC_PREFIX_REGEX, 'lmdc-');
+}

--- a/transform-to-lmdc.js
+++ b/transform-to-lmdc.js
@@ -1,0 +1,67 @@
+/**
+ * Convert HTML, CSS, and SCSS files to use the new classnames (lmdc-)
+ *
+ * Finds all classes referencing mdc- and replaces with lmdc-
+ *
+ * @example
+ * ```shell
+ * $ node @fintechstudios/angularjs-mdc/transform-to-lmdc ./src
+ * ```
+ *
+ * @fileOverview
+ */
+
+const process = require('process');
+const fsPromises = require('fs').promises;
+const path = require('path');
+
+const HTML_CLASSES_REGEX = /class="(.+?)"/g;
+const HTML_MDC_REGEX = /mdc-/g;
+const CSS_MDC_REGEX = /\.mdc-/g;
+const VALID_FILE = /\.(html|s?css)$/;
+
+function replaceHtmlClasses(fileContents) {
+  return fileContents.replace(HTML_CLASSES_REGEX, (fullMatch, classContents) => {
+    const withLmdc = classContents.replace(HTML_MDC_REGEX, 'lmdc-');
+
+    return `class="${withLmdc}"`;
+  })
+}
+
+function replaceCssClasses(fileContents) {
+  return fileContents.replace(CSS_MDC_REGEX, '.lmdc-');
+}
+
+async function replaceFilesInFolder(folder) {
+  const entities = await fsPromises.readdir(folder, { withFileTypes: true })
+
+  for (const entity of entities) {
+    const { name: fileName } = entity;
+    const filePath = path.join(folder, fileName);
+    if (entity.isDirectory()) {
+      await replaceFilesInFolder(filePath);
+      continue;
+    }
+
+    if (!VALID_FILE.test(fileName)) {
+      continue;
+    }
+    const fileBuffer = await fsPromises.readFile(filePath);
+    const contents = String(fileBuffer);
+    let newContents;
+    if (fileName.endsWith('.html')) {
+      newContents = replaceHtmlClasses(contents);
+    } else if (fileName.endsWith('.css') || fileName.endsWith('.scss')) {
+      newContents = replaceCssClasses(contents);
+    }
+    await fsPromises.writeFile(filePath, newContents);
+  }
+}
+
+async function main() {
+  const inputPath = process.argv[2] || process.cwd();
+  await replaceFilesInFolder(inputPath);
+}
+
+main()
+  .catch((err) => console.error(err));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,9 @@ const fs = require('fs');
 const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
+const transformMdcToLmdc = require('./scripts/transform-mdc-to-lmdc');
+
+
 // Used with webpack-dev-server
 const PUBLIC_PATH = '/assets/';
 const IS_DEV = process.env.MDC_ENV === 'development' || process.env.MDC_ENV === 'test';
@@ -26,7 +29,10 @@ const CSS_LOADER_CONFIG = [
     loader: 'postcss-loader',
     options: {
       sourceMap: IS_DEV,
-      plugins: () =>[require('autoprefixer')({grid: false})],
+      plugins: () =>[
+        require('autoprefixer')({grid: false}),
+        transformMdcToLmdc(),
+      ],
     },
   },
   {


### PR DESCRIPTION
Using `lmdc-` means there will not be conflicts with other version of `mdc`

BREAKING CHANGES:
* all classes have been changed from `mdc-` to `lmdc-` prefix
* A CLI script to assist migration is included:
```shell
$ node ./node-modules/@fintechstudios/angularjs-mdc/transform-to-lmdc <DIRECTORY>
```